### PR TITLE
Add 10ms sleep between I2C messages in bitbanged I2C

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0001-Add-10ms-sleep-between-I2C-messages-in-bitbanged-I2C.patch
+++ b/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0001-Add-10ms-sleep-between-I2C-messages-in-bitbanged-I2C.patch
@@ -1,0 +1,26 @@
+From 29c5fb50584bc4abafb2dfe11c8f7b70c97357da Mon Sep 17 00:00:00 2001
+From: Sebastian Panceac <sebastian@balena.io>
+Date: Tue, 27 Nov 2018 10:35:45 +0100
+Subject: [PATCH] Add 10ms sleep between I2C messages in bitbanged I2C
+
+Upstream-Status: Pending
+Signed-off-by: Sebastian Panceac <sebastian@balena.io>
+---
+ drivers/i2c/algos/i2c-algo-bit.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/i2c/algos/i2c-algo-bit.c b/drivers/i2c/algos/i2c-algo-bit.c
+index 1147bdd..e38b0f1 100644
+--- a/drivers/i2c/algos/i2c-algo-bit.c
++++ b/drivers/i2c/algos/i2c-algo-bit.c
+@@ -604,6 +604,7 @@ static int bit_xfer(struct i2c_adapter *i2c_adap,
+ 
+ 	if (adap->post_xfer)
+ 		adap->post_xfer(i2c_adap);
++	usleep_range(9000, 10000);
+ 	return ret;
+ }
+ 
+-- 
+2.7.4
+

--- a/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -5,6 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_append = " \
 	file://0001-Revert-cgroup-Disable-cgroup-memory-by-default.patch \
 	file://0003-media-uvcvideo-Fix-driver-reference-counting.patch \
+	file://0001-Add-10ms-sleep-between-I2C-messages-in-bitbanged-I2C.patch \
 	"
 
 # Set console accordingly to build type


### PR DESCRIPTION
We observed on the Balena Fin board that writing consecutive I2C
messages to the bitbanged I2C bus, with delays of a couple of
microsenconds between messages, causes the bus to throw errors or
can even cause SoC reset.
This patch adds a 1ms delay between consecutive I2C messages on the
bitbanged I2C interface to avoid the mentioned errors as they can
be seen in kernel logs:

[89397.944222] i2c i2c-3: sendbytes: NAK bailout.
[89397.944259] pca953x 3-0020: failed writing register
[89409.157111] i2c i2c-3: sendbytes: error -110

Signed-off-by: Sebastian Panceac <sebastian@balena.io>