### PR TITLE
linux-raspberrypi: Enable PCA963X led driver

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -79,3 +79,7 @@ RESIN_CONFIGS_DEPS[rpi_watchdog] = " \
 RESIN_CONFIGS[rpi_watchdog] = " \
     CONFIG_BCM2835_WDT=y \
 "
+RESIN_CONFIGS_append = " pca9633_led_driver"
+RESIN_CONFIGS[pca9633_led_driver] = " \
+    CONFIG_LEDS_PCA963X=y \
+    "


### PR DESCRIPTION
Enable the PCA963X LED driver module so we also support boards incorporating this family of integrated circuits.

fixes  #280 

Changelog-entry: Enable the PCA963X LED driver module so we also support boards incorporating this family of integrated circuits.
Signed-off-by: Carlo Maria Curinga <carlo@balena.io>