### PR TITLE
u-boot: Increase to 16 the USB interfaces number

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot/increase-usb-interface-nr.patch
+++ b/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot/increase-usb-interface-nr.patch
@@ -1,0 +1,31 @@
+From 3aab51b564ae90971fba1b8a633ee3aa64d926bc Mon Sep 17 00:00:00 2001
+From: Sebastian Panceac <sebastian@balena.io>
+Date: Mon, 14 Jan 2019 11:25:15 +0100
+Subject: [PATCH] Increase to 16 the number of USB interfaces
+
+This fixes the "Too many USB interfaces!" error thrown by u-boot when
+having lots of USB devices connected to the bus
+
+Signed-off-by: Sebastian Panceac <sebastian@balena.io>
+
+Upstream-Status: Pending
+---
+ include/usb.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/usb.h b/include/usb.h
+index b6b48a8c60..920464fcd7 100644
+--- a/include/usb.h
++++ b/include/usb.h
+@@ -33,7 +33,7 @@
+ 
+ #define USB_MAX_DEVICE			32
+ #define USB_MAXCONFIG			8
+-#define USB_MAXINTERFACES		8
++#define USB_MAXINTERFACES		16
+ #define USB_MAXENDPOINTS		16
+ #define USB_MAXCHILDREN			8	/* This is arbitrary */
+ #define USB_MAX_HUB			16
+-- 
+2.17.1
+

--- a/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -14,4 +14,5 @@ SRC_URI += " \
     file://0001-Integrate-machine-independent-resin-environment-conf.patch \
     file://rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch \
     file://bootcount-Add-support-to-write-bootcount-to-any-file.patch \
+    file://increase-usb-interface-nr.patch \
 "


### PR DESCRIPTION
This fixes the "Too many USB interfaces!" error thrown by u-boot when
having lots of USB devices connected to the bus

Changelog-entry: u-boot: Increase to 16 the USB interfaces number
Signed-off-by: Sebastian Panceac <sebastian@balena.io>