### PR TITLE
rpi-config: Prevent u-boot UART logging on RevPi Core3

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -35,6 +35,8 @@ dtparam=spi=on
 dtoverlay=kunbus
 
 EOF
+    # prevent u-boot logging on uart
+    sed -i 's/enable_uart=1//' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
 }
 
 # On Raspberry Pi 3 and Raspberry Pi Zero WiFi, serial ttyS0 console is only


### PR DESCRIPTION
This commit removes the "enable_uart=1" from config.txt
in debug builds to prevent u-boot from sending logs on
UART of RevPi Core3.
RevPi Core3 uses the UART interface to communicate with the
modules on RS485

Changelog-entry: rpi-config: Prevent u-boot UART logging on RevPi Core3
Signed-off-by: Sebastian Panceac <sebastian@balena.io>