### PR TITLE
kernel-devsrc: Add missing symlink for rpi3 arm64

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -1,0 +1,5 @@
+# create missing symlink for arm64 boards
+do_install_prepend() {
+    install -d ${D}${KERNEL_SRC_PATH}/arch/arm64/boot/dts/
+    ln -sf ../../../arm/boot/dts/overlays ${D}${KERNEL_SRC_PATH}/arch/arm64/boot/dts/overlays
+}


### PR DESCRIPTION
On the rpi3 64 bits the build fails with the following error:

| /yocto/resin-board/build/tmp/work/raspberrypi3_64-poky-linux/
kernel-devsrc/1.0-r0/image/usr/src/kernel/scripts/Makefile.clean:15
/yocto/resin-board/build/tmp/work/raspberrypi3_64-poky-linux/
kernel-devsrc/1.0-r0/image/usr/src/kernel/arch/arm64/boot/dts/broadcom/
../overlays/Makefile: No such file or directory
| make[4]: *** No rule to make target '/yocto/resin-board/build/tmp/work
/raspberrypi3_64-poky-linux/kernel-devsrc/1.0-r0/image/usr/src/kernel/
arch/arm64/boot/dts/broadcom/../overlays/Makefile'.  Stop.
| /yocto/resin-board/build/tmp/work/raspberrypi3_64-poky-linux/
kernel-devsrc/1.0-r0/image/usr/src/kernel/scripts/Makefile.clean:89
recipe for target 'arch/arm64/boot/dts/broadcom/../overlays' failed
| make[3]: *** [arch/arm64/boot/dts/broadcom/../overlays] Error 2
| /yocto/resin-board/build/tmp/work/raspberrypi3_64-poky-linux/
kernel-devsrc/1.0-r0/image/usr/src/kernel/scripts/Makefile.clean:89:
recipe for target 'arch/arm64/boot/dts/broadcom' failed
| make[2]: *** [arch/arm64/boot/dts/broadcom] Error 2
| make[2]: *** Waiting for unfinished jobs....
| arch/arm64/Makefile:152: recipe for target 'archclean' failed

Changelog-entry: Fix kernel-devsrc compilation on raspberrypi 3 arm64
Signed-off-by: Florin Sarbu <florin@balena.io>