### PR TITLE
Do not scan for usb devices during boot

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot/rpi.h-Remove-usb-start-from-CONFIG_PREBOOT.patch
+++ b/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot/rpi.h-Remove-usb-start-from-CONFIG_PREBOOT.patch
@@ -1,0 +1,27 @@
+From 51536458d69de6bee6dad55cba769e175ff7f0ad Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah Kakakhel <zubair@balena.io>
+Date: Wed, 13 Mar 2019 13:05:17 +0000
+Subject: [PATCH] rpi.h: Remove usb start from CONFIG_PREBOOT
+
+Changelog-entry: Remove usb start from CONFIG_PREBOOT. USB devices won't be scanned by default at boot by u-boot
+Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>
+Upstream-Status: Inappropriate [configuration]
+---
+ include/configs/rpi.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/include/configs/rpi.h b/include/configs/rpi.h
+index a97550b..b47f385 100644
+--- a/include/configs/rpi.h
++++ b/include/configs/rpi.h
+@@ -75,7 +75,6 @@
+ /* Environment */
+ #define CONFIG_ENV_SIZE			SZ_16K
+ #define CONFIG_SYS_LOAD_ADDR		0x1000000
+-#define CONFIG_PREBOOT			"usb start"
+ 
+ /* Shell */
+ 
+-- 
+2.7.4
+

--- a/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -15,4 +15,5 @@ SRC_URI += " \
     file://rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch \
     file://bootcount-Add-support-to-write-bootcount-to-any-file.patch \
     file://increase-usb-interface-nr.patch \
+    file://rpi.h-Remove-usb-start-from-CONFIG_PREBOOT.patch \
 "


### PR DESCRIPTION
u-boot currently scans usb devices during initialisation. This adds roughly 1-2 seconds of delay during boot. 
We don't need to check for usb devices on the pi as we don't flash an emmc from a usb device.

When https://github.com/balena-os/meta-balena/pull/1432 is merged in meta-balena, the default will be that usb devices won't be scanned for the presence of a flasher image either.