### PR TITLE
linux-kunbus.bb: Switch to version 4.9

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus.bb
+++ b/layers/meta-resin-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus.bb
@@ -1,10 +1,10 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-LINUX_VERSION = "4.14.44"
+LINUX_VERSION = "4.9.76"
 
-SRCREV = "6cc45d85b2835ae21d36289344a10cb45430360a"
+SRCREV = "4df2f71c072b25e04fbc84152f8bb9e5712bdea0"
 SRC_URI = " \
-	git://github.com/RevolutionPi/linux;branch=revpi-4.14 \
+	git://github.com/RevolutionPi/linux;branch=revpi-4.9 \
 "
 
 require linux-raspberrypi.inc

--- a/layers/meta-resin-raspberrypi/recipes-kernel/picontrol/picontrol.bb
+++ b/layers/meta-resin-raspberrypi/recipes-kernel/picontrol/picontrol.bb
@@ -5,12 +5,12 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 inherit module
 
 SRC_URI = " \
-	git://github.com/RevolutionPi/piControl;branch=revpi-4.14 \
+	git://github.com/RevolutionPi/piControl \
 	file://0001-Use-modules_install-as-wanted-by-yocto.patch \
 	file://0002-Search-config-file-in-mnt-boot.patch \
 "
 
-SRCREV ="f3f4e463d0269d8e4ef2b0a8d599cbf759326427"
+SRCREV ="raspberrypi-kernel_9.20190312-4.9.76+revpi1"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The kernel branch that Kunbus currently ships for their hardware
is revpi-4.9.

Changelog-entry: Switch revolution pi kernel to version 4.9
Signed-off-by: Florin Sarbu <florin@balena.io>