### PR TITLE
bluez5_%.bbappend: Remove brcm43438 service from fincm3 rootfs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "layers/poky"]
 	path = layers/poky
-	url = https://git.yoctoproject.org/git/poky
+	url = https://github.com/balena-os/poky
 [submodule "layers/meta-openembedded"]
 	path = layers/meta-openembedded
 	url = https://github.com/openembedded/meta-openembedded.git

--- a/layers/meta-resin-raspberrypi/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -7,3 +7,14 @@ do_install_append_raspberrypi() {
 SYSTEMD_SERVICE_${PN}_append_raspberrypi = " ${BCM_BT_SERVICE}"
 
 RDEPENDS_${PN}_append_raspberrypi = " ${BCM_BT_RDEPENDS}"
+
+# clear out the enable_bcm_bluetooth() function as we don't use the bcm chipset on the balena fin
+enable_bcm_bluetooth_fincm3() {
+    :
+}
+
+SRC_URI_remove_fincm3 = " ${BCM_BT_SOURCES}"
+
+SYSTEMD_SERVICE_${PN}_remove_fincm3 = "${BCM_BT_SERVICE}"
+
+RDEPENDS_${PN}_remove_fincm3 = "${BCM_BT_RDEPENDS}"


### PR DESCRIPTION
The Balena Fin does not use this chipset

Chnagelog-entry: Remove brcm43438 service from the Balena Fin rootfs
Signed-off-by: Florin Sarbu <florin@balena.io>