### PR TITLE
hostapp-update-hooks: Add config.txt quirk for revpi-core-3

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-support/hostapp-update-hooks/files/9999-bootfiles
+++ b/layers/meta-resin-raspberrypi/recipes-support/hostapp-update-hooks/files/9999-bootfiles
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+#
+# Script which applies a quirk to revpi-core-3's config.txt to remove an incompatible dtoverlay setting
+#
+
+set -o errexit
+
+printf "[INFO] Applying quirk to remove dtoverlay=mmc from config.txt"
+sed "/dtoverlay=mmc/d" /mnt/boot/config.txt > /mnt/boot/config.txt.new
+
+sync -f /mnt/boot
+mv /mnt/boot/config.txt.new /mnt/boot/config.txt
+sync -f /mnt/boot
+printf " done.\n"

--- a/layers/meta-resin-raspberrypi/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bbappend
@@ -1,3 +1,4 @@
 FILESEXTRAPATHS_append := ":${THISDIR}/files"
 
 HOSTAPP_HOOKS += " 99-resin-uboot 999-resin-boot-cleaner"
+HOSTAPP_HOOKS_append_revpi-core-3 = " 9999-bootfiles"


### PR DESCRIPTION
New balenaOS for revpi-core-3 will not boot if the config.txt
has an older dtoverlay=mmc entry.
Therefore we must add a hostapp update hook to remove this entry.

We name this quirk 9999-bootfiles to be sure it is run at the very
end so that no other hooks that may fail would run after it and as
such ending up rebooting in the older OS but with config.txt modified
by this quirk hook.

Changelog-entry: Add config.txt entry removal quirk for revpi-core-3
Signed-off-by: Florin Sarbu <florin@balena.io>