### PR TITLE
packagegroup-resin-connectivity: Add mt7601u firmware to rootfs for rpi0

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -1,1 +1,2 @@
 CONNECTIVITY_FIRMWARES_append = " linux-firmware-bcm43430 linux-firmware-bcm43455 linux-firmware-sd8887 linux-firmware-bcm43430a1-hcd linux-firmware-bcm4345c0-hcd"
+CONNECTIVITY_FIRMWARES_append_raspberrypi = " linux-firmware-mt7601u"


### PR DESCRIPTION
Customers are using wifi chipsets needing mt7601u firmware on rpi0

Changelog-entry: Add mt7601u firmware to rootfs for rpi0
Signed-off-by: Florin Sarbu <florin@balena.io>