### PR TITLE
Use Yocto Thud for the NPE X500 M3 board

### DIFF
--- a/npe-x500-m3.coffee
+++ b/npe-x500-m3.coffee
@@ -30,7 +30,7 @@ module.exports =
 		machine: 'npe-x500-m3'
 		image: 'resin-image'
 		fstype: 'resinos-img'
-		version: 'yocto-sumo'
+		version: 'yocto-thud'
 		deployArtifact: 'resin-image-npe-x500-m3.resinos-img'
 		compressed: true
 


### PR DESCRIPTION
Tested on an NPE X500 M3.
