### PR TITLE
bluez5_%.bbapend: Add BT dependency for the Balena machine

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,2 +1,5 @@
 SRC_URI_remove_fincm3 = " ${BCM_BT_SOURCES}"
 RDEPENDS_${PN}_remove_fincm3 = " ${BCM_BT_RDEPENDS}"
+
+SRC_URI_append_raspberrypi = " ${BCM_BT_SOURCES}"
+RDEPENDS_${PN}_append_raspberrypi = " ${BCM_BT_RDEPENDS}"


### PR DESCRIPTION
The pi-bluetooth gets chained in through
a dependency in bluetooth, in thud. This dependency
is defined in bluez5 and matches the machine.
Currently, the raspberrypi BSP only does it for
raspberrypi zero wireless and raspberrypi3.
To adapt this for the balena machine setup (which has
raspberrypi and raspberrypi zero wireless support in the
same machine) the same dependency needs to be added.

Changelog-entry: Add bluetooth dependency for the raspberrypi machine
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>