### PR TITLE
sd8887-mrvl: Update wlan and bt releases

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/sd8887-mrvl/sd8887-mrvl.bb
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/sd8887-mrvl/sd8887-mrvl.bb
@@ -5,11 +5,9 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca
 inherit module
 
 SRC_URI = " \
-    git://git@github.com/balena-io/sd8887-mrvl.git;protocol=ssh;branch=master \
+    git://git@github.com/balena-io/sd8887-mrvl.git;protocol=ssh;tag=v0.0.3 \
     file://COPYING \
 "
-
-SRCREV = "c1176184c72b14f06d56c30315a2b4f77c9fe797"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
We update to release 15.68.19.p22 for wlan and
15.26.19.p22 for bt.

Changelog-entry: Update sd8887-mrvl driver to 15.68.19.p22 for wlan and 15.26.19.p22 for bt
Signed-off-by: Florin Sarbu <florin@balena.io>