### PR TITLE
linux-kunbus.bb: Remove non-existing device tree reference

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/images/resin-image.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/images/resin-image.bbappend
@@ -44,4 +44,4 @@ IMAGE_INSTALL_append_rpi = " enable-overcommit u-boot"
 
 IMAGE_INSTALL_append_revpi-core-3 = " picontrol"
 
-RPI_KERNEL_DEVICETREE_remove_revpi-core-3 = "bcm2710-rpi-3-b-plus.dtb"
+RPI_KERNEL_DEVICETREE_remove_revpi-core-3 = "bcm2708-rpi-zero-w.dtb bcm2710-rpi-3-b-plus.dtb bcm2711-rpi-4-b.dtb"

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus.bb
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus.bb
@@ -9,4 +9,5 @@ SRC_URI = " \
 
 require linux-raspberrypi.inc
 
-RPI_KERNEL_DEVICETREE_remove = "bcm2710-rpi-3-b-plus.dtb"
+# the following device tree files are not available in this kernel version
+RPI_KERNEL_DEVICETREE_remove = "bcm2708-rpi-zero-w.dtb bcm2710-rpi-3-b-plus.dtb bcm2711-rpi-4-b.dtb"


### PR DESCRIPTION
The linux-kunbus source at version 4.9.76 has no device tree
called bcm2708-rpi-zero-w.dtb so we remove the reference to it
in order to avoid a build error.

Changelog-entry: revpi-core-3: Remove reference to non-existent device tree called bcm2708-rpi-zero-w.dtb in linux-kunbus version 4.9.76
Signed-off-by: Florin Sarbu <florin@balena.io>