### PR TITLE
bcm2835-bootfiles: Remove debug and old boot firmware for rpi4

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/bcm2835-bootfiles.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/bcm2835-bootfiles.bbappend
@@ -5,11 +5,30 @@ SRC_URI += " \
 "
 
 do_deploy_append() {
-    # exclude from resinOS the binaries with additional debug assertions (they
+    # exclude from balenaOS the binaries with additional debug assertions (they
     # grow the used size in resin-boot and this potentially breaks hostapps
     # update)
-    rm ${DEPLOYDIR}/${PN}/fixup_db.dat
-    rm ${DEPLOYDIR}/${PN}/start_db.elf
+    rm -f ${DEPLOYDIR}/${PN}/fixup_db.dat
+    rm -f ${DEPLOYDIR}/${PN}/start_db.elf
+    rm -f ${DEPLOYDIR}/${PN}/fixup4db.dat
+    rm -f ${DEPLOYDIR}/${PN}/start4db.elf
+    if [ "${MACHINE}" != "raspberrypi4-64" ]; then
+        # exclude RaspberryPi4 specific firmware from non raspberrypi4-64 balenaOS builds
+        rm -f ${DEPLOYDIR}/${PN}/fixup4.dat
+        rm -f ${DEPLOYDIR}/${PN}/fixup4cd.dat
+        rm -f ${DEPLOYDIR}/${PN}/fixup4x.dat
+        rm -f ${DEPLOYDIR}/${PN}/start4.elf
+        rm -f ${DEPLOYDIR}/${PN}/start4cd.elf
+        rm -f ${DEPLOYDIR}/${PN}/start4x.elf
+    else
+        # exclude from raspberrypi4-64 balenaOS the binaries which are for previous RaspberryPi versions
+        rm -f ${DEPLOYDIR}/${PN}/fixup.dat
+        rm -f ${DEPLOYDIR}/${PN}/fixup_cd.dat
+        rm -f ${DEPLOYDIR}/${PN}/fixup_x.dat
+        rm -f ${DEPLOYDIR}/${PN}/start.elf
+        rm -f ${DEPLOYDIR}/${PN}/start_cd.elf
+        rm -f ${DEPLOYDIR}/${PN}/start_x.elf
+    fi
 }
 
 do_deploy_append_fincm3() {


### PR DESCRIPTION
Do not add in balenaOS the files fixup4db.dat and start4db.elf which
are esentially versions of fixup4x.dat and start4x.elf with debug
assertions enabled.
Also remove all the old boot firmware which is present in the boot
partition (this older boot firmware is the one used for RaspberryPi
versions before version 4)

Changelog-entry: Remove debug and old boot firmware for RaspberryPi 4
Signed-off-by: Florin Sarbu <florin@balena.io>