### PR TITLE
sd8887-mrvl.bb: Update to tag v0.0.4

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/sd8887-mrvl/sd8887-mrvl.bb
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/sd8887-mrvl/sd8887-mrvl.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca
 inherit module
 
 SRC_URI = " \
-    git://git@github.com/balena-io/sd8887-mrvl.git;protocol=ssh;tag=v0.0.3 \
+    git://git@github.com/balena-io/sd8887-mrvl.git;protocol=ssh;tag=v0.0.4 \
     file://COPYING \
 "
 


### PR DESCRIPTION
This brings in Zahari's fix for the AP mode crash

Changelog-entry: Update the Balena Fin WiFi driver in order to fix AP mode crash
Signed-off-by: Florin Sarbu <florin@balena.io>