### PR TITLE
Exposing uAP interface on balenaFin

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/resin-extra-udev-rules/files/86-nm-unmanaged-fin.rules
+++ b/layers/meta-balena-raspberrypi/recipes-core/resin-extra-udev-rules/files/86-nm-unmanaged-fin.rules
@@ -1,0 +1,2 @@
+# balenaFin uAP interface needs to be unmanaged by default as NetworkManager does not support well AP mode.
+ACTION=="add|change", SUBSYSTEM=="net", ATTR{address}=="48:a4:93:*", ENV{INTERFACE}=="uap[0-9]*", ENV{NM_UNMANAGED}="1"

--- a/layers/meta-balena-raspberrypi/recipes-core/resin-extra-udev-rules/resin-extra-udev-rules.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/resin-extra-udev-rules/resin-extra-udev-rules.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/files"
+
+SRC_URI_append = " \
+	file://86-nm-unmanaged-fin.rules \
+	"
+
+do_install_append_fincm3() {
+	# Install balenaFin uAP interface rules
+	install -D -m 0644 ${WORKDIR}/86-nm-unmanaged-fin.rules ${D}/lib/udev/rules.d/86-nm-unmanaged-fin.rules
+}

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0005-balena-fin-wifi-sta-uap-mode.patch
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0005-balena-fin-wifi-sta-uap-mode.patch
@@ -1,0 +1,53 @@
+From 070ad28495cfe0269a1400e4ee5b3a2639aa12b8 Mon Sep 17 00:00:00 2001
+From: Zahari Petkov <zahari@balena.io>
+Date: Tue, 27 Aug 2019 15:40:53 +0200
+Subject: [PATCH] Switch balenaFin WiFi to STA+uAP mode and add DTS overrides
+
+In addition to enabling the uap0 interface, two parameters are exposed for
+overriding through config.txt.
+
+`wifi_dbg` could be used for tuning the verbosity of the WiFi driver.
+
+`wifi_mode` could be used for activating/deactivating WiFi interfaces. For
+example `dtparam=wifi_mode=1` will only expose the `wlan0` interface.
+
+For more information refer to the user manual:
+https://github.com/balena-io/sd8887-mrvl/tree/master/wlan_src
+
+Upstream-Status: Pending
+
+Signed-off-by: Zahari Petkov <zahari@balena.io>
+
+---
+ arch/arm/boot/dts/overlays/balena-fin-overlay.dts | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm/boot/dts/overlays/balena-fin-overlay.dts b/arch/arm/boot/dts/overlays/balena-fin-overlay.dts
+index a2cf8dcce782..e2bb06402c21 100644
+--- a/arch/arm/boot/dts/overlays/balena-fin-overlay.dts
++++ b/arch/arm/boot/dts/overlays/balena-fin-overlay.dts
+@@ -50,9 +50,9 @@
+ 				#size-cells = <0>;
+ 			};
+ 
+-			sd8xxx-wlan {
++			sd8xxx: sd8xxx-wlan {
+ 				drvdbg = <0x6>;
+-				drv_mode = <0x1>;
++				drv_mode = <0x3>;
+ 				cfg80211_wext = <0xf>;
+ 				sta_name = "wlan";
+ 				wfd_name = "p2p";
+@@ -113,4 +113,9 @@
+ 			};
+ 		};
+ 	};
++
++	__overrides__ {
++		wifi_mode       = <&sd8xxx>,"drv_mode:0";
++		wifi_dbg        = <&sd8xxx>,"drvdbg:0";
++	};
+ };
+-- 
+2.17.1
+

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -7,6 +7,7 @@ SRC_URI_append = " \
 	file://0003-leds-pca963x-Fix-MODE2-initialization.patch \
 	file://0001-Add-npe-x500-m3-overlay.patch \
 	file://0004-mmc-pwrseq-Repurpose-for-Marvell-SD8777.patch \
+	file://0005-balena-fin-wifi-sta-uap-mode.patch \
 "
 
 # Set console accordingly to build type

--- a/layers/meta-balena-raspberrypi/recipes-kernel/sd8887-mrvl/sd8887-mrvl.bb
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/sd8887-mrvl/sd8887-mrvl.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca
 inherit module
 
 SRC_URI = " \
-    git://git@github.com/balena-io/sd8887-mrvl.git;protocol=ssh;tag=v0.0.3 \
+    git://git@github.com/balena-io/sd8887-mrvl.git;protocol=ssh;tag=v0.0.4 \
     file://COPYING \
 "
 


### PR DESCRIPTION
This PR contains three commits:

* Including the latest Fin WiFi driver fix for AP mode
* Exposing the uAP interface through the device tree
* Adding an udev rule for marking it as unmanaged by NM