### PR TITLE
bcm2835-bootfiles: Do not deploy bootcode.bin for rpi4

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/bcm2835-bootfiles.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/bcm2835-bootfiles.bbappend
@@ -34,6 +34,8 @@ do_deploy_append() {
         rm -f ${DEPLOYDIR}/${PN}/start.elf
         rm -f ${DEPLOYDIR}/${PN}/start_cd.elf
         rm -f ${DEPLOYDIR}/${PN}/start_x.elf
+	# bootcode.bin is not used anymore on rpi4 as the boot code is now in an EEPROM (https://www.raspberrypi.org/documentation/hardware/raspberrypi/booteeprom.md)
+	rm -f ${DEPLOYDIR}/${PN}/bootcode.bin
     fi
 }
 


### PR DESCRIPTION
For rpi4 the bootcode is in an SPI EEPROM:
https://www.raspberrypi.org/documentation/hardware/
raspberrypi/booteeprom.md

Changelog-entry: Do not deploy bootcode.bin to boot partition for rpi4 as now the bootcode lives in an EEPROM
Signed-off-by: Florin Sarbu <florin@balena.io>