### PR TITLE
meta-balena-raspberrypi:layer.conf: Add hyperpixel4.dtbo to rootfs

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -48,6 +48,10 @@ KERNEL_DEVICETREE_append = " \
     overlays/hifiberry-digi-pro.dtbo \
     overlays/hy28a.dtbo \
     overlays/hy28b.dtbo \
+    overlays/hyperpixel4-pi3.dtbo \
+    overlays/hyperpixel4-pi4.dtbo \
+    overlays/hyperpixel4-square-pi3.dtbo \
+    overlays/hyperpixel4-square-pi4.dtbo \
     overlays/i2c0-bcm2708.dtbo \
     overlays/i2c1-bcm2708.dtbo \
     overlays/i2c-bcm2708.dtbo \
@@ -126,6 +130,9 @@ KERNEL_DEVICETREE_append_raspberrypi4-64 = " overlays/spi-gpio40-45.dtbo"
 
 # revpi-core-3 is on an older kernel release which does not have the following overlay
 KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/tpm-slb9670.dtbo"
+
+# the following overlays were added only for linux-raspberrypi so let's remove them for revpi-core-3 which uses linux-kunbus
+KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/hyperpixel4-pi3.dtbo overlays/hyperpixel4-pi4.dtbo overlays/hyperpixel4-square-pi3.dtbo overlays/hyperpixel4-square-pi4.dtbo"
 
 # We use udev rules to create serial device aliases
 SERIAL_CONSOLES = "115200;serial0"

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0006-overlays-Add-Hyperpixel4-overlays.patch
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0006-overlays-Add-Hyperpixel4-overlays.patch
@@ -1,0 +1,470 @@
+From ee5c0bab10e280cf54d3d2c06c6a4cc6b6ed627b Mon Sep 17 00:00:00 2001
+From: Florin Sarbu <florin@balena.io>
+Date: Thu, 17 Oct 2019 11:16:39 +0200
+Subject: [PATCH] overlays: Add Hyperpixel4 overlays
+
+These overlays are taken from https://github.com/pimoroni/hyperpixel4.git
+They each are taken from:
+  pi3                          df3f016 Merge pull request #37 from pimoroni/pi3-buster-fix
+  pi4                          c958d35 Add rotate instructions to install.sh
+  square                       a9c442f Updated README
+  square-pi4                   eebabef Update README.md
+
+Upstream-status: Inappropriate [not author]
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ arch/arm/boot/dts/overlays/Makefile                |   4 +
+ .../boot/dts/overlays/hyperpixel4-pi3-overlay.dts  |  98 ++++++++++++++++++++
+ .../boot/dts/overlays/hyperpixel4-pi4-overlay.dts  |  98 ++++++++++++++++++++
+ .../overlays/hyperpixel4-square-pi3-overlay.dts    | 103 +++++++++++++++++++++
+ .../overlays/hyperpixel4-square-pi4-overlay.dts    | 103 +++++++++++++++++++++
+ 5 files changed, 406 insertions(+)
+ create mode 100644 arch/arm/boot/dts/overlays/hyperpixel4-pi3-overlay.dts
+ create mode 100644 arch/arm/boot/dts/overlays/hyperpixel4-pi4-overlay.dts
+ create mode 100644 arch/arm/boot/dts/overlays/hyperpixel4-square-pi3-overlay.dts
+ create mode 100644 arch/arm/boot/dts/overlays/hyperpixel4-square-pi4-overlay.dts
+
+diff --git a/arch/arm/boot/dts/overlays/Makefile b/arch/arm/boot/dts/overlays/Makefile
+index 87082d6..554756c 100644
+--- a/arch/arm/boot/dts/overlays/Makefile
++++ b/arch/arm/boot/dts/overlays/Makefile
+@@ -59,6 +59,10 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
+ 	hy28a.dtbo \
+ 	hy28b.dtbo \
+ 	hy28b-2017.dtbo \
++	hyperpixel4-pi3.dtbo \
++	hyperpixel4-pi4.dtbo \
++	hyperpixel4-square-pi3.dtbo \
++	hyperpixel4-square-pi4.dtbo \
+ 	i-sabre-q2m.dtbo \
+ 	i2c-bcm2708.dtbo \
+ 	i2c-gpio.dtbo \
+diff --git a/arch/arm/boot/dts/overlays/hyperpixel4-pi3-overlay.dts b/arch/arm/boot/dts/overlays/hyperpixel4-pi3-overlay.dts
+new file mode 100644
+index 0000000..78bf59e
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/hyperpixel4-pi3-overlay.dts
+@@ -0,0 +1,98 @@
++/dts-v1/;
++/plugin/;
++/ {
++    compatible = "brcm,bcm2708";
++    fragment@0 {
++        target = <&fb>;
++        __overlay__ {
++            pinctrl-names = "default";
++            pinctrl-0 = <0x1>;
++        };
++    };
++    fragment@1 {
++        target = <&gpio>;
++        __overlay__ {
++            dpi18_pins {
++                brcm,pins = <0 1 2 3 4 5 6 7 8 9 12 13 14 15 16 17 20 21 22 23 24 25>;
++                brcm,function = <0x6>;
++                brcm,pull = <0x0>;
++                phandle = <0x1>;
++            };
++        };
++    };
++    fragment@2 {
++        target-path = "/";
++        __overlay__ {
++            rpi_backlight: rpi_backlight {
++                compatible = "gpio-backlight";
++                gpios = <&gpio 19 0>;
++                default-on;
++            };
++        };
++    };
++    fragment@3 {
++        target-path = "/";
++        __overlay__ {
++            i2c_gpio: i2c@0 {
++                compatible = "i2c-gpio";
++                gpios = <&gpio 10 0 /* sda */
++                     &gpio 11 0 /* scl */
++                    >;
++                i2c-gpio,delay-us = <4>;        /* ~100 kHz */
++                #address-cells = <1>;
++                #size-cells = <0>;
++            };
++        };
++    };
++    fragment@4 {
++        target = <&i2c_gpio>;
++        __overlay__ {
++            /* needed to avoid dtc warning */
++            #address-cells = <1>;
++            #size-cells = <0>;
++            ft6236: ft6236@5d {
++                compatible = "goodix,gt911";
++                reg = <0x5d>;
++                interrupt-parent = <&gpio>;
++                interrupts = <27 2>;
++                touchscreen-size-x = <480>;
++                touchscreen-size-y = <800>;
++                touchscreen-x-mm = <51>;
++                touchscreen-y-mm = <85>;
++            };
++        };
++    };
++    fragment@5 {
++        target = <&ft6236>;
++        __overlay__ {
++            touchscreen-swapped-x-y;
++        };
++    };
++    fragment@6 {
++        target = <&ft6236>;
++        __dormant__ {
++            touchscreen-inverted-x;
++        };
++    };
++    fragment@7 {
++        target = <&ft6236>;
++        __overlay__ {
++            touchscreen-inverted-y;
++        };
++    };
++    __symbols__ {
++        dpi18_pins = "/fragment@1/__overlay__/dpi18_pins";
++    };
++    __local_fixups__ {
++        fragment@0 {
++            __overlay__ {
++                pinctrl-0 = <0x0>;
++            };
++        };
++    };
++    __overrides__ {
++        touchscreen-inverted-x = <0>,"+6";
++        touchscreen-inverted-y = <0>,"-7";
++        touchscreen-swapped-x-y = <0>,"-5";
++    };
++};
+diff --git a/arch/arm/boot/dts/overlays/hyperpixel4-pi4-overlay.dts b/arch/arm/boot/dts/overlays/hyperpixel4-pi4-overlay.dts
+new file mode 100644
+index 0000000..3757a99
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/hyperpixel4-pi4-overlay.dts
+@@ -0,0 +1,98 @@
++/dts-v1/;
++/plugin/;
++/ {
++    compatible = "brcm,bcm2708";
++    fragment@0 {
++        target = <&fb>;
++        __overlay__ {
++            pinctrl-names = "default";
++            pinctrl-0 = <0x1>;
++        };
++    };
++    fragment@1 {
++        target = <&gpio>;
++        __overlay__ {
++            dpi18_pins {
++                brcm,pins = <0 1 2 3 4 5 6 7 8 9 12 13 14 15 16 17 20 21 22 23 24 25>;
++                brcm,function = <0x6>;
++                brcm,pull = <0x0>;
++                phandle = <0x1>;
++            };
++        };
++    };
++    fragment@2 {
++        target-path = "/";
++        __overlay__ {
++            rpi_backlight: rpi_backlight {
++                compatible = "gpio-backlight";
++                gpios = <&gpio 19 0>;
++                default-on;
++            };
++        };
++    };
++    fragment@3 {
++        target-path = "/";
++        __overlay__ {
++            i2c_gpio: i2c@0 {
++                compatible = "i2c-gpio";
++                gpios = <&gpio 10 0 /* sda */
++                     &gpio 11 0 /* scl */
++                    >;
++                i2c-gpio,delay-us = <4>;        /* ~100 kHz */
++                #address-cells = <1>;
++                #size-cells = <0>;
++            };
++        };
++    };
++    fragment@4 {
++        target = <&i2c_gpio>;
++        __overlay__ {
++            /* needed to avoid dtc warning */
++            #address-cells = <1>;
++            #size-cells = <0>;
++            ft6236: ft6236@14 {
++                compatible = "goodix,gt911";
++                reg = <0x14>;
++                interrupt-parent = <&gpio>;
++                interrupts = <27 2>;
++                touchscreen-size-x = <480>;
++                touchscreen-size-y = <800>;
++                touchscreen-x-mm = <51>;
++                touchscreen-y-mm = <85>;
++            };
++        };
++    };
++    fragment@5 {
++        target = <&ft6236>;
++        __overlay__ {
++            touchscreen-swapped-x-y;
++        };
++    };
++    fragment@6 {
++        target = <&ft6236>;
++        __dormant__ {
++            touchscreen-inverted-x;
++        };
++    };
++    fragment@7 {
++        target = <&ft6236>;
++        __overlay__ {
++            touchscreen-inverted-y;
++        };
++    };
++    __symbols__ {
++        dpi18_pins = "/fragment@1/__overlay__/dpi18_pins";
++    };
++    __local_fixups__ {
++        fragment@0 {
++            __overlay__ {
++                pinctrl-0 = <0x0>;
++            };
++        };
++    };
++    __overrides__ {
++        touchscreen-inverted-x = <0>,"+6";
++        touchscreen-inverted-y = <0>,"-7";
++        touchscreen-swapped-x-y = <0>,"-5";
++    };
++};
+diff --git a/arch/arm/boot/dts/overlays/hyperpixel4-square-pi3-overlay.dts b/arch/arm/boot/dts/overlays/hyperpixel4-square-pi3-overlay.dts
+new file mode 100644
+index 0000000..f544a6c
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/hyperpixel4-square-pi3-overlay.dts
+@@ -0,0 +1,103 @@
++/dts-v1/;
++/plugin/;
++/ {
++	compatible = "brcm,bcm2708";
++	fragment@0 {
++		target = <0xdeadbeef>;
++		__overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <0x1>;
++		};
++	};
++	fragment@1 {
++		target = <0xdeadbeef>;
++		__overlay__ {
++			dpi18_pins {
++				brcm,pins = <0x0 0x1 0x2 0x3 0x4 0x5 0x6 0x7 0x8 0x9	0xc 0xd 0xe 0xf 0x10 0x11	 0x14 0x15 0x16 0x17 0x18 0x19>;
++				brcm,function = <0x6>;
++				brcm,pull = <0x0>;
++				phandle = <0x1>;
++			};
++		};
++	};
++	fragment@2 {
++                target = <&gpio>;
++                __overlay__ {
++                        edt_ft5x06_pins: edt_ft5x06_pins {
++                                brcm,pins = <27>;
++                                brcm,function = <0>;
++                                brcm,pull = <2>;
++                        };
++                };
++	};
++	fragment@3 {
++		target-path = "/";
++		__overlay__ {
++			i2c_gpio: i2c@0 {
++				compatible = "i2c-gpio";
++				gpios = <&gpio 10 0 /* sda */
++					 &gpio 11 0 /* scl */
++					>;
++				i2c-gpio,delay-us = <1>;		/* ~100 kHz */
++				#address-cells = <1>;
++				#size-cells = <0>;
++			};
++		};
++	};
++	fragment@4 {
++		target = <&i2c_gpio>;
++                __overlay__ {
++                        #address-cells = <1>;
++                        #size-cells = <0>;
++                        status = "okay";
++
++                        polytouch: edt-ft5x06@48 {
++                                #address-cells = <1>;
++                                #size-cells = <0>;
++                                compatible = "edt,edt-ft5406", "edt,edt-ft5x06";
++                                reg = <0x48>;
++                                pinctrl-names = "default";
++                                pinctrl-0 = <&edt_ft5x06_pins>;
++                                interrupt-parent = <&gpio>;
++                                interrupts = <27 0x02>;
++                                touchscreen-size-x = <720>;
++                                touchscreen-size-y = <720>;
++                        };
++                };
++	};
++	fragment@5 {
++		target-path = "/";
++		__overlay__ {
++			rpi_backlight: rpi_backlight {
++				compatible = "gpio-backlight";
++				gpios = <&gpio 19 0>;
++				default-on;
++			};
++		};
++	};
++	fragment@6 {
++		target = <&polytouch>;
++		__overlay__ {
++			touchscreen-inverted-x = <1>;
++			touchscreen-inverted-y = <1>;
++		};
++	};
++	__symbols__ {
++		dpi18_pins = "/fragment@1/__overlay__/dpi18_pins";
++	};
++	__local_fixups__ {
++		fragment@0 {
++			__overlay__ {
++				pinctrl-0 = <0x0>;
++			};
++		};
++	};
++	__fixups__ {
++		leds = "/fragment@0:target:0";
++		gpio = "/fragment@1:target:0";
++	};
++	__overrides__ {
++		rotate = <0>,"-6";
++	};
++};
++
+diff --git a/arch/arm/boot/dts/overlays/hyperpixel4-square-pi4-overlay.dts b/arch/arm/boot/dts/overlays/hyperpixel4-square-pi4-overlay.dts
+new file mode 100644
+index 0000000..f544a6c
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/hyperpixel4-square-pi4-overlay.dts
+@@ -0,0 +1,103 @@
++/dts-v1/;
++/plugin/;
++/ {
++	compatible = "brcm,bcm2708";
++	fragment@0 {
++		target = <0xdeadbeef>;
++		__overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <0x1>;
++		};
++	};
++	fragment@1 {
++		target = <0xdeadbeef>;
++		__overlay__ {
++			dpi18_pins {
++				brcm,pins = <0x0 0x1 0x2 0x3 0x4 0x5 0x6 0x7 0x8 0x9	0xc 0xd 0xe 0xf 0x10 0x11	 0x14 0x15 0x16 0x17 0x18 0x19>;
++				brcm,function = <0x6>;
++				brcm,pull = <0x0>;
++				phandle = <0x1>;
++			};
++		};
++	};
++	fragment@2 {
++                target = <&gpio>;
++                __overlay__ {
++                        edt_ft5x06_pins: edt_ft5x06_pins {
++                                brcm,pins = <27>;
++                                brcm,function = <0>;
++                                brcm,pull = <2>;
++                        };
++                };
++	};
++	fragment@3 {
++		target-path = "/";
++		__overlay__ {
++			i2c_gpio: i2c@0 {
++				compatible = "i2c-gpio";
++				gpios = <&gpio 10 0 /* sda */
++					 &gpio 11 0 /* scl */
++					>;
++				i2c-gpio,delay-us = <1>;		/* ~100 kHz */
++				#address-cells = <1>;
++				#size-cells = <0>;
++			};
++		};
++	};
++	fragment@4 {
++		target = <&i2c_gpio>;
++                __overlay__ {
++                        #address-cells = <1>;
++                        #size-cells = <0>;
++                        status = "okay";
++
++                        polytouch: edt-ft5x06@48 {
++                                #address-cells = <1>;
++                                #size-cells = <0>;
++                                compatible = "edt,edt-ft5406", "edt,edt-ft5x06";
++                                reg = <0x48>;
++                                pinctrl-names = "default";
++                                pinctrl-0 = <&edt_ft5x06_pins>;
++                                interrupt-parent = <&gpio>;
++                                interrupts = <27 0x02>;
++                                touchscreen-size-x = <720>;
++                                touchscreen-size-y = <720>;
++                        };
++                };
++	};
++	fragment@5 {
++		target-path = "/";
++		__overlay__ {
++			rpi_backlight: rpi_backlight {
++				compatible = "gpio-backlight";
++				gpios = <&gpio 19 0>;
++				default-on;
++			};
++		};
++	};
++	fragment@6 {
++		target = <&polytouch>;
++		__overlay__ {
++			touchscreen-inverted-x = <1>;
++			touchscreen-inverted-y = <1>;
++		};
++	};
++	__symbols__ {
++		dpi18_pins = "/fragment@1/__overlay__/dpi18_pins";
++	};
++	__local_fixups__ {
++		fragment@0 {
++			__overlay__ {
++				pinctrl-0 = <0x0>;
++			};
++		};
++	};
++	__fixups__ {
++		leds = "/fragment@0:target:0";
++		gpio = "/fragment@1:target:0";
++	};
++	__overrides__ {
++		rotate = <0>,"-6";
++	};
++};
++
+-- 
+2.7.4
+

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -8,6 +8,7 @@ SRC_URI_append = " \
 	file://0001-Add-npe-x500-m3-overlay.patch \
 	file://0004-mmc-pwrseq-Repurpose-for-Marvell-SD8777.patch \
 	file://0005-balena-fin-wifi-sta-uap-mode.patch \
+	file://0006-overlays-Add-Hyperpixel4-overlays.patch \
 "
 
 # Set console accordingly to build type

--- a/raspberrypi.coffee
+++ b/raspberrypi.coffee
@@ -5,7 +5,7 @@ module.exports =
 	version: 1
 	slug: 'raspberry-pi'
 	aliases: [ 'raspberrypi' ]
-	name: 'Raspberry Pi (v1 and Zero)'
+	name: 'Raspberry Pi (v1 / Zero / Zero W)'
 	arch: 'rpi'
 	state: 'released'
 


### PR DESCRIPTION
This is an overlay used for the Pimoroni Hyperpixel 4.0 display.

Changelog-entry: Add to rootfs the overlay for Pimoroni Hyperpixel 4.0 display
Signed-off-by: Florin Sarbu <florin@balena.io>