### PR TITLE
balena-yocto-scripts: update to v1.3.8 to (re)enable custom supervisor tags

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
+++ b/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
@@ -43,7 +43,7 @@ RPI_USE_U_BOOT = "1"
 #RESINHUP ?= "yes"
 
 # Set this to change the supervisor tag used
-#TARGET_TAG ?= "master"
+#SUPERVISOR_TAG ?= "master"
 
 # Compress final raw image
 #RESIN_RAW_IMG_COMPRESSION ?= "xz"


### PR DESCRIPTION
Also update the the `local.conf` sample file.

Changelog-entry: update balena-yocto-scripts and local.conf sample for supervisor tags
Connects-to: balena-os/balena-yocto-scripts#156
Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>