### PR TITLE
[RPi4] Add support for vl805 firmware update (without BalenaOS 2.45.0 update)

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/images/resin-image.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/images/resin-image.bbappend
@@ -20,6 +20,7 @@ RESIN_BOOT_PARTITION_FILES_rpi = " \
 
 RESIN_BOOT_PARTITION_FILES_append_raspberrypi4-64 = " \
     rpi-eeprom/pieeprom-latest-stable.bin:/pieeprom-latest-stable.bin \
+    rpi-eeprom/vl805-latest-stable.bin:/vl805-latest-stable.bin \
 "
 
 python overlay_dtbs_handler () {
@@ -48,9 +49,9 @@ IMAGE_INSTALL_append_rpi = " enable-overcommit u-boot"
 
 IMAGE_INSTALL_append_revpi-core-3 = " picontrol"
 
-# Tools necessary for SPI EEPROM bootloader update during HUP.
-# dtc is called internally at runtime by userlandtools/dtoverlay.
-IMAGE_INSTALL_append_raspberrypi4-64 = " flashrom userlandtools dtc"
-DEPENDS_append_raspberrypi4-64 = " rpi-eeprom"
+# Tools necessary for SPI EEPROM bootloader and vl805 firmware
+# update during HUP. dtc is called internally at runtime by
+# userlandtools/dtoverlay.
+IMAGE_INSTALL_append_raspberrypi4-64 = " flashrom userlandtools dtc rpi-eeprom"
 
 RPI_KERNEL_DEVICETREE_remove_revpi-core-3 = "bcm2708-rpi-zero-w.dtb bcm2710-rpi-3-b-plus.dtb bcm2711-rpi-4-b.dtb"

--- a/layers/meta-balena-raspberrypi/recipes-support/hostapp-update-hooks/files/97-vl805fw
+++ b/layers/meta-balena-raspberrypi/recipes-support/hostapp-update-hooks/files/97-vl805fw
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+#
+# This hook updates raspberrypi4 vl805 firmware
+#
+
+set -o errexit
+
+CURR_IMG=vl805fw-current.bin.tmp
+CURR_IMG_PATH=/dev/shm
+NEW_IMG=vl805-latest-stable.bin
+NEW_IMG_PATH=/mnt/boot
+
+/usr/sbin/vl805 -r ${CURR_IMG_PATH}/${CURR_IMG} || true
+
+# Don't fail if firmware cannot be read
+# for some reason
+if [ ! -f ${CURR_IMG_PATH}/${CURR_IMG} ]; then
+    echo "[WARN] Could not read current vl805 firmware!"
+    exit 0
+fi;
+
+curr_vl805fw_md5sum=$(md5sum ${CURR_IMG_PATH}/${CURR_IMG} | awk '{print $1}')
+new_vl805fw_md5sum=$(md5sum ${NEW_IMG_PATH}/${NEW_IMG} | awk '{print $1}')
+
+if [ $curr_vl805fw_md5sum = $new_vl805fw_md5sum ]; then
+    echo "[INFO] vl805 firmware update is not necessary"
+else
+    echo "[INFO] Performing vl805 firmware update..."
+    /usr/sbin/vl805 -w ${NEW_IMG_PATH}/${NEW_IMG} || true
+fi
+
+rm ${CURR_IMG_PATH}/$CURR_IMG

--- a/layers/meta-balena-raspberrypi/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bbappend
@@ -2,3 +2,4 @@ FILESEXTRAPATHS_append := ":${THISDIR}/files"
 
 HOSTAPP_HOOKS += " 99-resin-uboot 999-resin-boot-cleaner"
 HOSTAPP_HOOKS_append_revpi-core-3 = " 9999-bootfiles"
+HOSTAPP_HOOKS_append_raspberrypi4-64 = " 97-vl805fw"


### PR DESCRIPTION
This PR adds support for vl805 firmware update, as requested in https://github.com/balena-os/balena-raspberrypi/issues/383

<strike>vl805 executable is added in this PR because it is the only version that is statically linked and can be used in the hostOS. It is provided in the raspberrypi forums: https://www.raspberrypi.org/forums/viewtopic.php?f=28&t=250990

The latest public firmware release is obtained from the raspbian package repository, which DOES NOT have the fix needed yet. This PR should not be merged until the firmware fix is released.

Question has been addressed to the rpi maintainers for when and where will the firmware with the overheating fix will be available.</strike>

All vl805 binaries are now obtained from rpi-eeprom repository.