### PR TITLE
resin-extra-udev-rules.bbappend: Do not filter balenaFin uAP interface by address

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/resin-extra-udev-rules/files/86-nm-unmanaged-fin.rules
+++ b/layers/meta-balena-raspberrypi/recipes-core/resin-extra-udev-rules/files/86-nm-unmanaged-fin.rules
@@ -1,2 +1,2 @@
 # balenaFin uAP interface needs to be unmanaged by default as NetworkManager does not support well AP mode.
-ACTION=="add|change", SUBSYSTEM=="net", ATTR{address}=="48:a4:93:*", ENV{INTERFACE}=="uap[0-9]*", ENV{NM_UNMANAGED}="1"
+ACTION=="add|change", SUBSYSTEM=="net", ENV{INTERFACE}=="uap[0-9]*", ENV{NM_UNMANAGED}="1"


### PR DESCRIPTION
The maker of the balenaFin WiFi module (Taiyo Yuden) has two MAC address ranges, so we should not filter the uAP interface by MAC address range, but only by name.

Changelog-entry: Do not filter balenaFin uAP interface by address
Signed-off-by: Zahari Petkov <zahari@balena.io>