### PR TITLE
[RPI4] Avoid kernel panic if booting with Sensehat

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0001-Fbcon-ignore-events-for-rpi-sense-fb.patch
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0001-Fbcon-ignore-events-for-rpi-sense-fb.patch
@@ -1,0 +1,46 @@
+From 9072ef03f8f43cd16ec1a2e639391044d335e8c7 Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Fri, 18 Oct 2019 14:54:11 +0200
+Subject: [PATCH] fbcon: ignore events for rpi sense framebuffer
+
+Various crashes occurr in the fb core
+when RPI Sensehat's 8x8 pixel display fb is
+bound to a fbconsole.
+
+Don't attach consoles to this particular
+framebuffer to avoid kernel panics in the
+fb core.
+
+Crashes won't occur if another framebuffer
+was previously created, because console does
+not get switched to the sensehat in that case.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ drivers/video/fbdev/core/fbcon.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/drivers/video/fbdev/core/fbcon.c b/drivers/video/fbdev/core/fbcon.c
+index f7ac64d692b2..ff480d4d7144 100644
+--- a/drivers/video/fbdev/core/fbcon.c
++++ b/drivers/video/fbdev/core/fbcon.c
+@@ -3338,6 +3338,15 @@ static int fbcon_event_notify(struct notifier_block *self,
+ 				  action == FB_EVENT_FB_UNREGISTERED))
+ 		goto done;
+ 
++	/* If no other framebuffer is availabe, then sensehat's
++	 * will be used. But it's an 8x8 pixels display, not meant for this.
++	 * Ignore all events for rpi-sense fb and don't attach a console to it.
++	 */
++	if (info && !strncmp(info->fix.id, "RPi-Sense FB", 12))
++	{
++		goto done;
++	}
++
+ 	switch(action) {
+ 	case FB_EVENT_SUSPEND:
+ 		fbcon_suspended(info);
+-- 
+2.17.1
+

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -11,6 +11,10 @@ SRC_URI_append = " \
 	file://0006-overlays-Add-Hyperpixel4-overlays.patch \
 "
 
+SRC_URI_append_raspberrypi4-64 = " \
+        file://0001-Fbcon-ignore-events-for-rpi-sense-fb.patch \
+"
+
 # Set console accordingly to build type
 DEBUG_CMDLINE = "dwc_otg.lpm_enable=0 console=tty1 console=serial0,115200 rootfstype=ext4 rootwait"
 PRODUCTION_CMDLINE = "dwc_otg.lpm_enable=0 console=null rootfstype=ext4 rootwait vt.global_cursor_default=0"


### PR DESCRIPTION
If fbcon binds to the Sensehat's 8x8 display
framebuffer, various crashes will appear
when preparing images for being drawn
on the display, in the fbdev core.

This small display is not meant for console,
therefore fbcon should not takeover the fb
created by its' driver.

Kernel panics do not occur if another
framebuffer is already present and used,
as console is not switched to this new one.

That's why enabling hdmi_force_output
makes the issue dissapear.