### PR TITLE
hostapp-update-hooks: Disable eeprom update temporarily

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bbappend
@@ -2,4 +2,3 @@ FILESEXTRAPATHS_append := ":${THISDIR}/files"
 
 HOSTAPP_HOOKS += " 99-resin-uboot 999-resin-boot-cleaner"
 HOSTAPP_HOOKS_append_revpi-core-3 = " 9999-bootfiles"
-HOSTAPP_HOOKS_append_raspberrypi4-64 = " 98-pieeprom"


### PR DESCRIPTION
Kernel update uncovered an issue with modules
being loaded from the new os container during hup.
Loading modules with a new version from the new OS
will trigger failure of the hup hook.

Disable this hook temporarily so we can fix
the issues we uncovered during release testing.