### PR TITLE
raspberrypi4-64.coffee: Clean-up device pretty name

### DIFF
--- a/raspberrypi4-64.coffee
+++ b/raspberrypi4-64.coffee
@@ -5,7 +5,7 @@ module.exports =
 	version: 1
 	slug: 'raspberrypi4-64'
 	aliases: [ 'raspberrypi4-64' ]
-	name: 'Raspberry Pi 4 (using 64bit OS)'
+	name: 'Raspberry Pi 4'
 	arch: 'aarch64'
 	state: 'experimental'
 


### PR DESCRIPTION
We only support 64 bits OS for the pi4 so let's not
explicitly mention it.

Changelog-entry: Remove the 64 bits OS reference from the rpi4 device pretty name
Signed-off-by: Florin Sarbu <florin@balena.io>