### PR TITLE
linux-raspberrypi_%.bbappend: Move specific fincm3 patches to fincm3 …

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -2,12 +2,15 @@ inherit kernel-resin
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
+SRC_URI_append_fincm3 = " \
+	file://0004-mmc-pwrseq-Repurpose-for-Marvell-SD8777.patch \
+	file://0005-balena-fin-wifi-sta-uap-mode.patch \
+"
+
 SRC_URI_append = " \
 	file://0002-wireless-wext-Bring-back-ndo_do_ioctl-fallback.patch \
 	file://0003-leds-pca963x-Fix-MODE2-initialization.patch \
 	file://0001-Add-npe-x500-m3-overlay.patch \
-	file://0004-mmc-pwrseq-Repurpose-for-Marvell-SD8777.patch \
-	file://0005-balena-fin-wifi-sta-uap-mode.patch \
 	file://0006-overlays-Add-Hyperpixel4-overlays.patch \
 "
 


### PR DESCRIPTION
…machine

Some specific fincm3 patches were applying to
all the raspberry pi machines.
This lead to kernel startup failure of the pi4-64
machine. No serial output was shown after the
"Starting kernel..." log and the board would
freeze.

Changelog-entry: Fix rpi4-64 kernel freeze by moving specific fincm3 patches
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>