### PR TITLE
u-boot: Disable flasher check, add usb

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-rpi-Disable-image-flasher-check.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-rpi-Disable-image-flasher-check.patch
@@ -1,0 +1,35 @@
+From 851a975a3843cb5eb13395a350dd326f2c638f0b Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Fri, 6 Dec 2019 14:16:21 +0100
+Subject: [PATCH] rpi: Disable image flasher check
+
+Since there's no need to check for
+flasher image, we disable this check
+so that the command "usb start" is not
+executed without reason when booting
+from sd-card, IF "usb" is also present
+in resin_uboot_device_types array.
+
+Upstream-status: Inappropriate[configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ include/configs/rpi.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/include/configs/rpi.h b/include/configs/rpi.h
+index e2760b0f84..92d2433bbe 100644
+--- a/include/configs/rpi.h
++++ b/include/configs/rpi.h
+@@ -157,7 +157,8 @@
+ 	"dhcpuboot=usb start; dhcp u-boot.uimg; bootm\0" \
+ 	ENV_DEVICE_SETTINGS \
+ 	ENV_MEM_LAYOUT_SETTINGS \
+-	BOOTENV
++	BOOTENV \
++	"resin_flasher_skip=1\0"
+ 
+ 
+ #endif
+-- 
+2.17.1
+

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -16,3 +16,11 @@ SRC_URI += " \
     file://rpi.h-Remove-usb-start-from-CONFIG_PREBOOT.patch \
     file://0002-raspberrypi-Disable-simple-framebuffer-support.patch \
 "
+
+# Disable flasher check since it starts usb unnecessarily
+# and we don't generate flasher images for any of the RPIs.
+SRC_URI_append = " \
+    file://0001-rpi-Disable-image-flasher-check.patch \
+"
+
+RESIN_UBOOT_DEVICE_TYPES_append = " usb"


### PR DESCRIPTION
By default flasher check comes enabled from
meta-balena, but none of the raspberrypi
machines generate a flasher image.

Disabling this allows for adding 'usb' to
resin_uboot_device_types without actually
starting usb, unless and until it is confirmed that
there's no balena image on the sd-card.

With this change:
- uboot first attempts to load the kernel from the sd-card, if it is present and contains a balenaOS image. it looks no further for the usb, nor does it call "usb start" in this case.

- if no image is detected on the sd-card, usb will be started and checked for a balenaOS image, from where kernel will be loaded

Note: Added for rpi3-64, but we could very well extend for other machines too.
Addresses: https://github.com/balena-os/balena-raspberrypi/issues/341


