### PR TITLE
conf/layer.conf: Add spi3 to spi6 overlays

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -109,6 +109,14 @@ KERNEL_DEVICETREE_append = " \
     overlays/spi2-1cs.dtbo \
     overlays/spi2-2cs.dtbo \
     overlays/spi2-3cs.dtbo \
+    overlays/spi3-1cs.dtbo \
+    overlays/spi3-2cs.dtbo \
+    overlays/spi4-1cs.dtbo \
+    overlays/spi4-2cs.dtbo \
+    overlays/spi5-1cs.dtbo \
+    overlays/spi5-2cs.dtbo \
+    overlays/spi6-1cs.dtbo \
+    overlays/spi6-2cs.dtbo \
     overlays/spi-gpio35-39.dtbo \
     overlays/spi-rtc.dtbo \
     overlays/tinylcd35.dtbo \


### PR DESCRIPTION
Customer request to have spi 3 to 6 enabled
in balenaOS

Changelog-entry: Enable spi3 to spi6 device tree overlays
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>