### PR TITLE
conf/layer.conf: Remove spi3 to spi6 overlays from revpi-core-3

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -136,8 +136,16 @@ KERNEL_DEVICETREE_append_npe-x500-m3 = " overlays/npe-x500-m3.dtbo"
 # for updating boot EEPROM on RPI4
 KERNEL_DEVICETREE_append_raspberrypi4-64 = " overlays/spi-gpio40-45.dtbo"
 
-# revpi-core-3 is on an older kernel release which does not have the following overlay
+# revpi-core-3 is on an older kernel release which does not have the following overlays
 KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/tpm-slb9670.dtbo"
+KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/spi3-1cs.dtbo"
+KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/spi3-2cs.dtbo"
+KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/spi4-1cs.dtbo"
+KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/spi4-2cs.dtbo"
+KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/spi5-1cs.dtbo"
+KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/spi5-2cs.dtbo"
+KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/spi6-1cs.dtbo"
+KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/spi6-2cs.dtbo"
 
 # the following overlays were added only for linux-raspberrypi so let's remove them for revpi-core-3 which uses linux-kunbus
 KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/hyperpixel4-pi3.dtbo overlays/hyperpixel4-pi4.dtbo overlays/hyperpixel4-square-pi3.dtbo overlays/hyperpixel4-square-pi4.dtbo"


### PR DESCRIPTION
We have added at customer request the device tree overlays for the
spi buses 3 to 6. But revpi-core-3 is running an older kernel which
does not have these overlays.

Changelog-entry: Remove spi3 to spi6 overlays for revpi-core-3 because it runs an older kernel which does not have them
Signed-off-by: Florin Sarbu <florin@balena.io>