### PR TITLE
Update the Fin instructions to match the hardware.

### DIFF
--- a/fincm3.coffee
+++ b/fincm3.coffee
@@ -1,7 +1,7 @@
 deviceTypesCommon = require '@resin.io/device-types/common'
 { networkOptions, commonImg, instructions } = deviceTypesCommon
 
-FIN_DEBUG = "While not having the Fin board powered, connect your system to the board's DBG port via a micro-USB cable.."
+FIN_DEBUG = "While not having the Fin board powered, connect your system to the board's DBG/PRG port via a micro-USB cable.."
 FIN_POWER = "Power on the Fin by attaching power to either the Barrel or the Phoenix connector."
 FIN_WRITE = "Write the OS to the internal MMC storage device. We recommend using <a href=http://www.etcher.io/>Etcher</a>."
 FIN_POWEROFF = "When flashing is complete, power off the board by detaching the power and unplug the DGB micro-USB cable."


### PR DESCRIPTION
The instructions for installing software on the Fin are not consistent with the actual hardware (at least the hardware that I have). On the UI it calls it the "DBG port" and on the hardware it's the "PRG port".  This PR includes the tiny change to make it so.

<img width="1312" alt="screenshot" src="https://user-images.githubusercontent.com/59449/72108802-3cb92180-3399-11ea-8338-a9a5fa9caa74.png">

![fin](https://user-images.githubusercontent.com/59449/72108816-43479900-3399-11ea-9973-312bc6962a1a.jpeg)
