### PR TITLE
layer.conf: Add uart2 to uart5 overlays

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -124,6 +124,10 @@ KERNEL_DEVICETREE_append = " \
     overlays/tpm-slb9670.dtbo \
     overlays/uart0.dtbo \
     overlays/uart1.dtbo \
+    overlays/uart2.dtbo \
+    overlays/uart3.dtbo \
+    overlays/uart4.dtbo \
+    overlays/uart5.dtbo \
     overlays/vc4-fkms-v3d.dtbo \
     overlays/vga666.dtbo \
     overlays/wittypi.dtbo \
@@ -148,6 +152,10 @@ KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/spi5-2cs.dtbo"
 KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/spi6-1cs.dtbo"
 KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/spi6-2cs.dtbo"
 KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/gpio-ir-tx.dtbo"
+KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/uart2.dtbo"
+KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/uart3.dtbo"
+KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/uart4.dtbo"
+KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/uart5.dtbo"
 
 # the following overlays were added only for linux-raspberrypi so let's remove them for revpi-core-3 which uses linux-kunbus
 KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/hyperpixel4-pi3.dtbo overlays/hyperpixel4-pi4.dtbo overlays/hyperpixel4-square-pi3.dtbo overlays/hyperpixel4-square-pi4.dtbo"


### PR DESCRIPTION
We add the uart2 to uart5 overlays to the rootfs alongside the
existing uart0 and uart1 overlays.

Changelog-entry: Add the uart2 to uart5 overlays to rootfs
Signed-off-by: Florin Sarbu <florin@balena.io>