### PR TITLE
u-boot: Prevent blocking when writing to serial console

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-avoid-block-uart-write.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-avoid-block-uart-write.patch
@@ -1,0 +1,50 @@
+From 5e960cc9b208c53d5385d5a2f6c7f380e9499d4c Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Wed, 18 Mar 2020 16:54:28 +0100
+Subject: [PATCH] Add a retry limit when writing to uart console
+
+Seems that if the serial console is incorrectly
+configured in the dtb, writing to it may block indefinitely,
+thus preventing the board from booting.
+
+Let's add a retry count to unblock in such cases.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ drivers/serial/serial_bcm283x_mu.c | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/serial/serial_bcm283x_mu.c b/drivers/serial/serial_bcm283x_mu.c
+index bd1d89ec83..bd033d14c4 100644
+--- a/drivers/serial/serial_bcm283x_mu.c
++++ b/drivers/serial/serial_bcm283x_mu.c
+@@ -49,7 +49,7 @@ struct bcm283x_mu_regs {
+ struct bcm283x_mu_priv {
+ 	struct bcm283x_mu_regs *regs;
+ };
+-
++static uint16_t putc_retry = 0;
+ static int bcm283x_mu_serial_getc(struct udevice *dev);
+ 
+ static int bcm283x_mu_serial_setbrg(struct udevice *dev, int baudrate)
+@@ -105,8 +105,14 @@ static int bcm283x_mu_serial_putc(struct udevice *dev, const char data)
+ 	struct bcm283x_mu_regs *regs = priv->regs;
+ 
+ 	/* Wait until there is space in the FIFO */
+-	if (!(readl(&regs->lsr) & BCM283X_MU_LSR_TX_EMPTY))
+-		return -EAGAIN;
++	if (!(readl(&regs->lsr) & BCM283X_MU_LSR_TX_EMPTY)) {
++		if (++putc_retry) {
++			return -EAGAIN;
++		} else {
++			/* Couldn't write for too long, drop char */
++			return 0;
++		}
++	}
+ 
+ 	/* Send the character */
+ 	writel(data, &regs->io);
+-- 
+2.17.1
+

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -15,6 +15,7 @@ SRC_URI += " \
     file://increase-usb-interface-nr.patch \
     file://rpi.h-Remove-usb-start-from-CONFIG_PREBOOT.patch \
     file://0002-raspberrypi-Disable-simple-framebuffer-support.patch \
+    file://0001-avoid-block-uart-write.patch \
 "
 
 # Disable flasher check since it starts usb unnecessarily


### PR DESCRIPTION
It appears that when the console is incorrectly configured
in the dtb, booting will get stuck while trying to write
chars to the uart.

Let's avoid this by not blocking indefinitely.

Changelog-entry: u-boot: Prevent blocking when writing to serial console
Signed-off-by: Alexandru Costache <alexandru@balena.io>