### PR TITLE
u-boot: Fix FAT WRITE issue for bootcount

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-fs-fat-allocate-a-new-cluster-for-root-directory-of-.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-fs-fat-allocate-a-new-cluster-for-root-directory-of-.patch
@@ -1,0 +1,53 @@
+From cd2d727fff7ea4c69db49d7ee63bd791f91acd26 Mon Sep 17 00:00:00 2001
+From: AKASHI Takahiro <takahiro.akashi@linaro.org>
+Date: Fri, 24 May 2019 14:10:37 +0900
+Subject: [PATCH] fs: fat: allocate a new cluster for root directory of fat32
+
+Contrary to fat12/16, fat32 can have root directory at any location
+and its size can be expanded.
+Without this patch, root directory won't grow properly and so we will
+eventually fail to add files under root directory. Please note that this
+can happen even if you delete many files as deleted directory entries
+are not reclaimed but just marked as "deleted" under the current
+implementation.
+
+Upstream-status: Inappropriate [Backport]
+Signed-off-by: AKASHI Takahiro <takahiro.akashi@linaro.org>
+Tested-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
+Signed-off-by: Alexandru Costche <alexandru@balena.io>
+---
+ fs/fat/fat_write.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/fs/fat/fat_write.c b/fs/fat/fat_write.c
+index 5ea15fab3a..729cf39630 100644
+--- a/fs/fat/fat_write.c
++++ b/fs/fat/fat_write.c
+@@ -247,8 +247,11 @@ fill_dir_slot(fat_itr *itr, const char *l_name)
+ 		if (itr->remaining == 0)
+ 			flush_dir(itr);
+ 
++		/* allocate a cluster for more entries */
+ 		if (!fat_itr_next(itr))
+-			if (!itr->dent && !itr->is_root && new_dir_table(itr))
++			if (!itr->dent &&
++			    (!itr->is_root || itr->fsdata->fatsize == 32) &&
++			    new_dir_table(itr))
+ 				return -1;
+ 	}
+ 
+@@ -980,7 +983,10 @@ static dir_entry *find_directory_entry(fat_itr *itr, char *filename)
+ 			return itr->dent;
+ 	}
+ 
+-	if (!itr->dent && !itr->is_root && new_dir_table(itr))
++	/* allocate a cluster for more entries */
++	if (!itr->dent &&
++	    (!itr->is_root || itr->fsdata->fatsize == 32) &&
++	    new_dir_table(itr))
+ 		/* indicate that allocating dent failed */
+ 		itr->dent = NULL;
+ 
+-- 
+2.17.1
+

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-fs-fat-flush-a-directory-cluster-properly.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-fs-fat-flush-a-directory-cluster-properly.patch
@@ -1,0 +1,112 @@
+From 9c709c7b4177d063733070c7256f0b8635996d65 Mon Sep 17 00:00:00 2001
+From: AKASHI Takahiro <takahiro.akashi@linaro.org>
+Date: Fri, 24 May 2019 14:10:36 +0900
+Subject: [PATCH] fs: fat: flush a directory cluster properly
+
+When a long name directory entry is created, multiple directory entries
+may be occupied across a directory cluster boundary. Since only one
+directory cluster is cached in a directory iterator, a first cluster must
+be written back to device before switching over a second cluster.
+
+Without this patch, some added files may be lost even if you don't see
+any failures on write operation.
+
+Upstream-status: Inappropriate [Backport]
+Signed-off-by: AKASHI Takahiro <takahiro.akashi@linaro.org>
+Tested-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ fs/fat/fat_write.c | 33 ++++++++++++++-------------------
+ 1 file changed, 14 insertions(+), 19 deletions(-)
+
+diff --git a/fs/fat/fat_write.c b/fs/fat/fat_write.c
+index 11b85d35ed..5ea15fab3a 100644
+--- a/fs/fat/fat_write.c
++++ b/fs/fat/fat_write.c
+@@ -209,7 +209,8 @@ name11_12:
+ 	return 1;
+ }
+ 
+-static int flush_dir_table(fat_itr *itr);
++static int new_dir_table(fat_itr *itr);
++static int flush_dir(fat_itr *itr);
+ 
+ /*
+  * Fill dir_slot entries with appropriate name, id, and attr
+@@ -242,19 +243,15 @@ fill_dir_slot(fat_itr *itr, const char *l_name)
+ 		memcpy(itr->dent, slotptr, sizeof(dir_slot));
+ 		slotptr--;
+ 		counter--;
++
++		if (itr->remaining == 0)
++			flush_dir(itr);
++
+ 		if (!fat_itr_next(itr))
+-			if (!itr->dent && !itr->is_root && flush_dir_table(itr))
++			if (!itr->dent && !itr->is_root && new_dir_table(itr))
+ 				return -1;
+ 	}
+ 
+-	if (!itr->dent && !itr->is_root)
+-		/*
+-		 * don't care return value here because we have already
+-		 * finished completing an entry with name, only ending up
+-		 * no more entry left
+-		 */
+-		flush_dir_table(itr);
+-
+ 	return 0;
+ }
+ 
+@@ -621,18 +618,14 @@ static int find_empty_cluster(fsdata *mydata)
+ }
+ 
+ /*
+- * Write directory entries in itr's buffer to block device
++ * Allocate a cluster for additional directory entries
+  */
+-static int flush_dir_table(fat_itr *itr)
++static int new_dir_table(fat_itr *itr)
+ {
+ 	fsdata *mydata = itr->fsdata;
+ 	int dir_newclust = 0;
+ 	unsigned int bytesperclust = mydata->clust_size * mydata->sect_size;
+ 
+-	if (set_cluster(mydata, itr->clust, itr->block, bytesperclust) != 0) {
+-		printf("error: writing directory entry\n");
+-		return -1;
+-	}
+ 	dir_newclust = find_empty_cluster(mydata);
+ 	set_fatent_value(mydata, itr->clust, dir_newclust);
+ 	if (mydata->fatsize == 32)
+@@ -987,7 +980,7 @@ static dir_entry *find_directory_entry(fat_itr *itr, char *filename)
+ 			return itr->dent;
+ 	}
+ 
+-	if (!itr->dent && !itr->is_root && flush_dir_table(itr))
++	if (!itr->dent && !itr->is_root && new_dir_table(itr))
+ 		/* indicate that allocating dent failed */
+ 		itr->dent = NULL;
+ 
+@@ -1164,14 +1157,16 @@ int file_fat_write_at(const char *filename, loff_t pos, void *buffer,
+ 
+ 		memset(itr->dent, 0, sizeof(*itr->dent));
+ 
+-		/* Set short name to set alias checksum field in dir_slot */
++		/* Calculate checksum for short name */
+ 		set_name(itr->dent, filename);
++
++		/* Set long name entries */
+ 		if (fill_dir_slot(itr, filename)) {
+ 			ret = -EIO;
+ 			goto exit;
+ 		}
+ 
+-		/* Set attribute as archive for regular file */
++		/* Set short name entry */
+ 		fill_dentry(itr->fsdata, itr->dent, filename, 0, size, 0x20);
+ 
+ 		retdent = itr->dent;
+-- 
+2.17.1
+

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-fs-fat-write-to-non-cluster-aligned-root-directory.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-fs-fat-write-to-non-cluster-aligned-root-directory.patch
@@ -1,0 +1,163 @@
+From a9f6706cf0ba330281ae7d6a0af65cc26ffb7d25 Mon Sep 17 00:00:00 2001
+From: AKASHI Takahiro <takahiro.akashi@linaro.org>
+Date: Fri, 24 May 2019 14:10:35 +0900
+Subject: [PATCH] fs: fat: write to non-cluster-aligned root directory
+
+With the commit below, fat now correctly handles a file read under
+a non-cluster-aligned root directory of fat12/16.
+Write operation should be fixed in the same manner.
+
+Fixes: commit 9b18358dc05d ("fs: fat: fix reading non-cluster-aligned
+       root directory")
+
+Upstream-status: Inappropriate [Backport]
+Signed-off-by: AKASHI Takahiro <takahiro.akashi@linaro.org>
+Cc: Anssi Hannula <anssi.hannula@bitwise.fi>
+Tested-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ fs/fat/fat_write.c | 78 +++++++++++++++++++++++++++++++---------------
+ 1 file changed, 53 insertions(+), 25 deletions(-)
+
+diff --git a/fs/fat/fat_write.c b/fs/fat/fat_write.c
+index 2a74199236..11b85d35ed 100644
+--- a/fs/fat/fat_write.c
++++ b/fs/fat/fat_write.c
+@@ -388,29 +388,23 @@ static __u32 determine_fatent(fsdata *mydata, __u32 entry)
+ }
+ 
+ /**
+- * set_cluster() - write data to cluster
++ * set_sectors() - write data to sectors
+  *
+- * Write 'size' bytes from 'buffer' into the specified cluster.
++ * Write 'size' bytes from 'buffer' into the specified sector.
+  *
+  * @mydata:	data to be written
+- * @clustnum:	cluster to be written to
++ * @startsect:	sector to be written to
+  * @buffer:	data to be written
+  * @size:	bytes to be written (but not more than the size of a cluster)
+  * Return:	0 on success, -1 otherwise
+  */
+ static int
+-set_cluster(fsdata *mydata, u32 clustnum, u8 *buffer, u32 size)
++set_sectors(fsdata *mydata, u32 startsect, u8 *buffer, u32 size)
+ {
+-	u32 idx = 0;
+-	u32 startsect;
++	u32 nsects = 0;
+ 	int ret;
+ 
+-	if (clustnum > 0)
+-		startsect = clust_to_sect(mydata, clustnum);
+-	else
+-		startsect = mydata->rootdir_sect;
+-
+-	debug("clustnum: %d, startsect: %d\n", clustnum, startsect);
++	debug("startsect: %d\n", startsect);
+ 
+ 	if ((unsigned long)buffer & (ARCH_DMA_MINALIGN - 1)) {
+ 		ALLOC_CACHE_ALIGN_BUFFER(__u8, tmpbuf, mydata->sect_size);
+@@ -429,17 +423,16 @@ set_cluster(fsdata *mydata, u32 clustnum, u8 *buffer, u32 size)
+ 			size -= mydata->sect_size;
+ 		}
+ 	} else if (size >= mydata->sect_size) {
+-		idx = size / mydata->sect_size;
+-		ret = disk_write(startsect, idx, buffer);
+-		if (ret != idx) {
++		nsects = size / mydata->sect_size;
++		ret = disk_write(startsect, nsects, buffer);
++		if (ret != nsects) {
+ 			debug("Error writing data (got %d)\n", ret);
+ 			return -1;
+ 		}
+ 
+-		startsect += idx;
+-		idx *= mydata->sect_size;
+-		buffer += idx;
+-		size -= idx;
++		startsect += nsects;
++		buffer += nsects * mydata->sect_size;
++		size -= nsects * mydata->sect_size;
+ 	}
+ 
+ 	if (size) {
+@@ -457,6 +450,44 @@ set_cluster(fsdata *mydata, u32 clustnum, u8 *buffer, u32 size)
+ 	return 0;
+ }
+ 
++/**
++ * set_cluster() - write data to cluster
++ *
++ * Write 'size' bytes from 'buffer' into the specified cluster.
++ *
++ * @mydata:	data to be written
++ * @clustnum:	cluster to be written to
++ * @buffer:	data to be written
++ * @size:	bytes to be written (but not more than the size of a cluster)
++ * Return:	0 on success, -1 otherwise
++ */
++static int
++set_cluster(fsdata *mydata, u32 clustnum, u8 *buffer, u32 size)
++{
++	return set_sectors(mydata, clust_to_sect(mydata, clustnum),
++			   buffer, size);
++}
++
++static int
++flush_dir(fat_itr *itr)
++{
++	fsdata *mydata = itr->fsdata;
++	u32 startsect, sect_offset, nsects;
++
++	if (!itr->is_root || mydata->fatsize == 32)
++		return set_cluster(mydata, itr->clust, itr->block,
++				   mydata->clust_size * mydata->sect_size);
++
++	sect_offset = itr->clust * mydata->clust_size;
++	startsect = mydata->rootdir_sect + sect_offset;
++	/* do not write past the end of rootdir */
++	nsects = min_t(u32, mydata->clust_size,
++		       mydata->rootdir_size - sect_offset);
++
++	return set_sectors(mydata, startsect, itr->block,
++			   nsects * mydata->sect_size);
++}
++
+ static __u8 tmpbuf_cluster[MAX_CLUSTSIZE] __aligned(ARCH_DMA_MINALIGN);
+ 
+ /*
+@@ -1163,8 +1194,7 @@ int file_fat_write_at(const char *filename, loff_t pos, void *buffer,
+ 	}
+ 
+ 	/* Write directory table to device */
+-	ret = set_cluster(mydata, itr->clust, itr->block,
+-			  mydata->clust_size * mydata->sect_size);
++	ret = flush_dir(itr);
+ 	if (ret) {
+ 		printf("Error: writing directory entry\n");
+ 		ret = -EIO;
+@@ -1241,8 +1271,7 @@ static int delete_dentry(fat_itr *itr)
+ 	memset(dentptr, 0, sizeof(*dentptr));
+ 	dentptr->name[0] = 0xe5;
+ 
+-	if (set_cluster(mydata, itr->clust, itr->block,
+-			mydata->clust_size * mydata->sect_size) != 0) {
++	if (flush_dir(itr)) {
+ 		printf("error: writing directory entry\n");
+ 		return -EIO;
+ 	}
+@@ -1444,8 +1473,7 @@ int fat_mkdir(const char *new_dirname)
+ 	}
+ 
+ 	/* Write directory table to device */
+-	ret = set_cluster(mydata, itr->clust, itr->block,
+-			  mydata->clust_size * mydata->sect_size);
++	ret = flush_dir(itr);
+ 	if (ret)
+ 		printf("Error: writing directory entry\n");
+ 
+-- 
+2.17.1
+

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -18,6 +18,15 @@ SRC_URI += " \
     file://0001-avoid-block-uart-write.patch \
 "
 
+# Below patches come from upstream u-boot 2020.04, they seem to fix the
+# "Error: allocating new dir entry" issue and may be removed once updated u-boot
+# from BSP will include them:
+SRC_URI += " \
+   file://0001-fs-fat-write-to-non-cluster-aligned-root-directory.patch \
+   file://0001-fs-fat-flush-a-directory-cluster-properly.patch \
+   file://0001-fs-fat-allocate-a-new-cluster-for-root-directory-of-.patch \
+"
+
 # Disable flasher check since it starts usb unnecessarily
 # and we don't generate flasher images for any of the RPIs.
 SRC_URI_append = " \


### PR DESCRIPTION
We backport these 3 patches from upstream u-boot
2020.04 as they seem to fix a sporadic
HUP issue where boot count fails to be saved from
environment:

Error: allocating new dir entry
** Unable to write "bootcount.env" from mmc 0:1 **
FATWRITE FAILED

They seem to fix the issues with altboot here: https://github.com/balena-os/balena-raspberrypi/issues/470 and this one here: https://github.com/balena-os/balena-raspberrypi/issues/380

Issue seems to be reproducible after HUP-ing between releases, i.e. a 2.43 clean flash will not exhibit this, but a HUP to 2.43 will do. From that point on, consecutive HUPs to 2.48.0 will still exhibit the issue, both local and staging builds, both development and production. After HUP-ing to a build with these changes, the issue disappeared. 

Manged to reproduce and tested these scenario 2 times.