### PR TITLE
Enable Kvaser USB CAN driver

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -89,6 +89,12 @@ RESIN_CONFIGS[rpi_watchdog] = " \
     CONFIG_BCM2835_WDT=y \
 "
 
+RESIN_CONFIGS_append = " kvaser_usb_can_driver"
+
+RESIN_CONFIGS[kvaser_usb_can_driver] = " \
+    CONFIG_CAN_KVASER_USB=m \
+"
+
 RESIN_CONFIGS_append = " mcp251x_can_driver"
 
 RESIN_CONFIGS[mcp251x_can_driver] = " \


### PR DESCRIPTION
This PR enables Kvaser's CAN USB driver to support their USB interfaces.
The motivation is using a Balena Fin with a Kvaser Mini PCI Express HS interface or any other RPi based board with one of their USB interfaces (e.g, Leaf).