### PR TITLE
layers/meta-raspberrypi: Waveshare SIM7600 module for ModemManager

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -130,6 +130,7 @@ KERNEL_DEVICETREE_append = " \
     overlays/uart5.dtbo \
     overlays/vc4-fkms-v3d.dtbo \
     overlays/vga666.dtbo \
+    overlays/waveshare-sim7600.dtbo \
     overlays/wittypi.dtbo \
 "
 
@@ -156,6 +157,7 @@ KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/uart2.dtbo"
 KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/uart3.dtbo"
 KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/uart4.dtbo"
 KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/uart5.dtbo"
+KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/waveshare-sim7600.dtbo"
 
 # the following overlays were added only for linux-raspberrypi so let's remove them for revpi-core-3 which uses linux-kunbus
 KERNEL_DEVICETREE_remove_revpi-core-3 = "overlays/hyperpixel4-pi3.dtbo overlays/hyperpixel4-pi4.dtbo overlays/hyperpixel4-square-pi3.dtbo overlays/hyperpixel4-square-pi4.dtbo"

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0001-waveshare-sim7600-Add-dtbo-for-this-modem.patch
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0001-waveshare-sim7600-Add-dtbo-for-this-modem.patch
@@ -1,0 +1,57 @@
+From d83c8ded1a60d34e913a6b30b9ad3c99d9ea4558 Mon Sep 17 00:00:00 2001
+From: User Name <user@email.io>
+Date: Fri, 1 May 2020 13:17:42 +0200
+Subject: [PATCH] overlays: Add waveshare-sim7600 dtbo
+
+This adds dtbo necessary for GPIO setup
+for the waveshare-sim7600 modem.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Martijn <ask@minusplusminus.com>
+---
+ arch/arm/boot/dts/overlays/Makefile           |  1 +
+ .../boot/dts/overlays/waveshare-sim7600-overlay.dts   | 20 +++++++++++++++++++
+ 2 files changed, 21 insertions(+)
+ create mode 100644 arch/arm/boot/dts/overlays/waveshare-sim7600-overlay.dts
+
+diff --git a/arch/arm/boot/dts/overlays/Makefile b/arch/arm/boot/dts/overlays/Makefile
+index 554756c3265f..a32f31486bc9 100644
+--- a/arch/arm/boot/dts/overlays/Makefile
++++ b/arch/arm/boot/dts/overlays/Makefile
+@@ -186,6 +186,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
+ 	vga666.dtbo \
+ 	w1-gpio.dtbo \
+ 	w1-gpio-pullup.dtbo \
++	waveshare-sim7600.dtbo \
+ 	wittypi.dtbo
+ 
+ targets += dtbs dtbs_install
+diff --git a/arch/arm/boot/dts/overlays/waveshare-sim7600-overlay.dts b/arch/arm/boot/dts/overlays/waveshare-sim7600-overlay.dts
+new file mode 100644
+index 000000000000..7295ecec1220
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/waveshare-sim7600-overlay.dts
+@@ -0,0 +1,20 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++    compatible = "brcm,bcm2708,bcm2710,bcm2711";
++
++    fragment@0 {
++        target = <&gpio>;
++        __overlay__ {
++            pinctrl-names = "default";
++            pinctrl-0 = <&modem_pins>;
++
++            modem_pins: modem_pins {
++                brcm,pins = <4 6>;     /* GPIO pins */
++                brcm,function = <1 1>; /* Output */
++                brcm,pull = <2 2>; /* pull high */
++            };
++        };
++    };
++};
+-- 
+2.17.1
+

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -12,6 +12,7 @@ SRC_URI_append = " \
 	file://0003-leds-pca963x-Fix-MODE2-initialization.patch \
 	file://0001-Add-npe-x500-m3-overlay.patch \
 	file://0006-overlays-Add-Hyperpixel4-overlays.patch \
+	file://0001-waveshare-sim7600-Add-dtbo-for-this-modem.patch \
 "
 
 SRC_URI_append_raspberrypi4-64 = " \


### PR DESCRIPTION
To use the Waveshare SIM7600 module, GPIO pins must be set in dtoverlay, so that module is active on boot.

see [balena forums problems-with-custom-image-on-rasberry-pi](https://forums.balena.io/t/problems-with-custom-image-on-rasberry-pi/100947/11) for more info

Changelog-entry: add dtbo to layer.conf so that dtoverlay is possible
Signed-off-by: Martijn <ask@minusplusminus.com>