### PR TITLE
linux-raspberrypi: Remove kernel check config warning

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
@@ -153,7 +153,7 @@ RESIN_CONFIGS_DEPS[mcp3422_adc_driver] = " \
 RESIN_CONFIGS_append = " sd8787_pwrseq_driver"
 
 RESIN_CONFIGS[sd8787_pwrseq_driver] = " \
-    CONFIG_PWRSEQ_SD8787=y \
+    CONFIG_PWRSEQ_SD8787=m \
 "
 
 RESIN_CONFIGS_DEPS[sd8787_pwrseq_driver] = " \


### PR DESCRIPTION
The PWRSEQ_SD8787 driver depends on either MWIFIEX or
BT_MRVL_SDIO and both are configured as modules.

Change the inclusion of PWRSEQ_SD8787 from built-in to
module to match the dependencies.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>