### PR TITLE
linux-raspberrypi: Use 1GB kernel / 3GB userspace memory split for 32-bit kernels

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
@@ -161,6 +161,6 @@ RESIN_CONFIGS_DEPS[sd8787_pwrseq_driver] = " \
 "
 
 RESIN_CONFIGS_append = " vmsplit"
-RESIN_CONFIGS[vmsplit] = " \
+RESIN_CONFIGS_DEPS[vmsplit] = " \
     CONFIG_VMSPLIT_3G=y \
 "

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
@@ -159,3 +159,8 @@ RESIN_CONFIGS[sd8787_pwrseq_driver] = " \
 RESIN_CONFIGS_DEPS[sd8787_pwrseq_driver] = " \
     CONFIG_OF=y \
 "
+
+RESIN_CONFIGS_append = " vmsplit"
+RESIN_CONFIGS[vmsplit] = " \
+    CONFIG_VMSPLIT_3G=y \
+"


### PR DESCRIPTION
At this moment we are using the default 2GB kernel / 2GB userspace
memory split which causes issues for the application that need to
map more than 2GB of memory (e.g. balena engine). The other 32-bit
boards default to 1GB kernel / 3GB userspace ratio which seems to
be more reasonable in general.

Change-type: patch
Changelog-entry: Use 1GB kernel / 3GB userspace memory split for 32-bit kernels
Signed-off-by: Michal Toman <michalt@balena.io>