### PR TITLE
u-boot: Avoid freeze while booting production builds

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/rpi4-disable-pl01-serial-driver.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/rpi4-disable-pl01-serial-driver.patch
@@ -1,0 +1,32 @@
+From 53f5425ec5979df0b2db210505c3dea84e6fb2c8 Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Thu, 27 Aug 2020 14:27:46 +0200
+Subject: [PATCH] pl01: Disable driver in production builds
+
+Do so when enable_uart is not set in config.txt,
+otherwise the Pi4 will freeze during boot. We don't
+want to output anything to the serial console while
+u-boot is running anyway.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ drivers/serial/serial_pl01x.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/serial/serial_pl01x.c b/drivers/serial/serial_pl01x.c
+index 6e5d81ce34..199bef2f4f 100644
+--- a/drivers/serial/serial_pl01x.c
++++ b/drivers/serial/serial_pl01x.c
+@@ -375,7 +375,7 @@ int pl01x_serial_ofdata_to_platdata(struct udevice *dev)
+ U_BOOT_DRIVER(serial_pl01x) = {
+ 	.name	= "serial_pl01x",
+ 	.id	= UCLASS_SERIAL,
+-	.of_match = of_match_ptr(pl01x_serial_id),
++	.of_match = NULL,
+ 	.ofdata_to_platdata = of_match_ptr(pl01x_serial_ofdata_to_platdata),
+ 	.platdata_auto_alloc_size = sizeof(struct pl01x_serial_platdata),
+ 	.probe = pl01x_serial_probe,
+-- 
+2.17.1
+

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -66,3 +66,11 @@ SRC_URI_append_raspberrypi4-64 = " \
     file://Revert-remove-include-config_defaults.h.patch \
     file://rpi4-include-configs-Use-config-defaults.patch \
 "
+
+# In production builds enable_uart is not set, and this makes
+# the pi4 serial driver freeze. Let's not use this driver in
+# production, because we don't want to output anything to the
+# console anyway.
+SRC_URI_append_raspberrypi4-64 = " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'development-image', '', 'file://rpi4-disable-pl01-serial-driver.patch', d)} \
+"

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/rpi4-fix-usb-boot-8GB.patch
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/rpi4-fix-usb-boot-8GB.patch
@@ -1,0 +1,44 @@
+From cea09d48c9da6bb7cb441527b5ab95e064718479 Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Fri, 28 Aug 2020 14:52:27 +0200
+Subject: [PATCH] rp4: Fix USB boot on Pi4 8GB
+
+Without this patch, u-boot will fail to load
+and reboot continuously on 8GB Pi4 when booting
+from USB.
+
+See: https://patchwork.ozlabs.org/project/linux-pci/patch/20200629161845.6021-5-nsaenzjulienne@suse.de/
+
+Upstream-status: pending
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ arch/arm/boot/dts/bcm2711-rpi-4-b.dts | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+index 0c4abbdc794c..513cae21e64c 100644
+--- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
++++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+@@ -198,9 +198,17 @@
+ };
+ 
+ &pcie0 {
+-	usb@1,0 {
++	pci@1,0 {
++		#address-cells = <3>;
++		#size-cells = <2>;
++		ranges;
++
+ 		reg = <0 0 0 0 0>;
+-		resets = <&reset RASPBERRYPI_FIRMWARE_RESET_ID_USB>;
++
++		usb@1,0 {
++			reg = <0x10000 0 0 0 0>;
++			resets = <&reset RASPBERRYPI_FIRMWARE_RESET_ID_USB>;
++		};
+ 	};
+ };
+ 
+-- 
+2.17.1
+

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
@@ -22,6 +22,7 @@ SRC_URI_append_raspberrypi4-64 = " \
 	file://0004-ARM-dts-bcm2711-Add-reset-controller-to-xHCI-node.patch \
 	file://0007-usb-host-pci-quirks-Bypass-xHCI-quirks-for-Raspberry-Pi-4.patch \
 	file://0008-usb-xhci-pci-Raspberry-Pi-FW-loader-for-VIA-VL805.patch \
+	file://rpi4-fix-usb-boot-8GB.patch \
 "
 
 # Set console accordingly to build type


### PR DESCRIPTION
In production images enable_uart is not set in config.txt
and we don't want to output anything to the console either.
Let's not load the pl11 serial driver for PI4 because it freezes boot when
enable_uart is not set.

Changelog-entry: Avoid freeze while booting production builds
Signed-off-by: Alexandru Costache <alexandru@balena.io>