### PR TITLE
README: Rename resin to Balena in layer readme

### DIFF
--- a/layers/meta-balena-raspberrypi/README.md
+++ b/layers/meta-balena-raspberrypi/README.md
@@ -1,7 +1,7 @@
 # Resin.io layer for meta-raspberrypi supported boards
 
 ## Description
-This repository enables building resin.io for chosen meta-raspberrypi machines.
+This repository enables building BalenaOS for chosen meta-raspberrypi machines.
 
 ## Supported machines
 * fincm3
@@ -11,5 +11,5 @@ This repository enables building resin.io for chosen meta-raspberrypi machines.
 
 ## How to?
 
-Q: I generated an image without debug or I downloaded a resin image from the production dashboard. How can I login over serial port?
-A: We don't start getty on non debug images. As well there are passward changes for root user needed. In order to simplify this process, there is a helper script https://github.com/resin-os/serial-it which does everything for you. Check the help message of that script.
+Q: I generated an image without debug or I downloaded a Balena image from the production dashboard. How can I login over serial port?
+A: We don't start getty on non debug images. As well there are passward changes for root user needed. In order to simplify this process, there is a helper script https://github.com/balena-os/serial-it which does everything for you. Check the help message of that script.


### PR DESCRIPTION
Changelog-entry: README: Rename resin to Balena in layer readme
Signed-off-by: Alexandru Costache <alexandru@balena.io>