### PR TITLE
u-boot: fix possible freeze in uart driver

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-avoid-block-uart-write.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-avoid-block-uart-write.patch
@@ -24,7 +24,7 @@ index bd1d89ec83..bd033d14c4 100644
  	struct bcm283x_mu_regs *regs;
  };
 -
-+static uint16_t putc_retry = 0;
++static uint16_t putc_retry;
  static int bcm283x_mu_serial_getc(struct udevice *dev);
  
  static int bcm283x_mu_serial_setbrg(struct udevice *dev, int baudrate)


### PR DESCRIPTION
It was reported that in certain configurations
u-boot can possibly freeze with putc_retry located
in bss instead of data. This because the serial
driver is used before relocating.

Changelog-entry: u-boot: fix possible freeze in uart driver
Signed-off-by: Alexandru Costache <alexandru@balena.io>