### PR TITLE
u-boot: fix possible freeze in uart driver

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/rpi4-avoid-block-uart-write.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/rpi4-avoid-block-uart-write.patch
@@ -25,7 +25,7 @@ index 0102b10ed2..d9b6f0febf 100644
  	struct bcm283x_mu_regs *regs;
  };
  
-+static uint16_t putc_retry = 0;
++static uint16_t putc_retry;
  static int bcm283x_mu_serial_getc(struct udevice *dev);
  
  static int bcm283x_mu_serial_setbrg(struct udevice *dev, int baudrate)


### PR DESCRIPTION
This change is already present for the majority
of the Pi boards, let's add it for the Pi4 rebased
patch too.