### PR TITLE
bcm2835-bootfiles: Use proper bootfiles for rt-rpi-300

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
+++ b/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
@@ -9,6 +9,7 @@
 #MACHINE ?= "npe-x500-m3"
 #MACHINE ?= "rt-rpi-300"
 
+BALENA_STORAGE_rt-rpi-300 = "overlay2"
 BALENA_STORAGE_raspberrypi4-64 = "overlay2"
 BALENA_STORAGE_revpi-connect = "overlay2"
 

--- a/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/bcm2835-bootfiles.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/bcm2835-bootfiles.bbappend
@@ -20,7 +20,7 @@ do_deploy_append() {
     rm -f ${DEPLOYDIR}/${PN}/start_db.elf
     rm -f ${DEPLOYDIR}/${PN}/fixup4db.dat
     rm -f ${DEPLOYDIR}/${PN}/start4db.elf
-    if [ "${MACHINE}" != "raspberrypi4-64" ]; then
+    if [ "${MACHINE}" != "raspberrypi4-64" ] && [ "${MACHINE}" != "rt-rpi-300" ] ; then
         # exclude RaspberryPi4 specific firmware from non raspberrypi4-64 balenaOS builds
         rm -f ${DEPLOYDIR}/${PN}/fixup4.dat
         rm -f ${DEPLOYDIR}/${PN}/fixup4cd.dat


### PR DESCRIPTION
Changelog-entry: Use proper bootfiles for rt-rpi-300
Signed-off-by: Florin Sarbu <florin@balena.io>