### PR TITLE
Revert "linux-raspberrypi: Use 1GB kernel / 3GB userspace memory split for 32-bit kernels"

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
@@ -168,6 +168,6 @@ RESIN_CONFIGS_DEPS[sd8787_pwrseq_driver] = " \
 "
 
 RESIN_CONFIGS_append = " vmsplit"
-RESIN_CONFIGS_DEPS[vmsplit] = " \
+RESIN_CONFIGS[vmsplit] = " \
     CONFIG_VMSPLIT_3G=y \
 "

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
@@ -166,8 +166,3 @@ RESIN_CONFIGS[sd8787_pwrseq_driver] = " \
 RESIN_CONFIGS_DEPS[sd8787_pwrseq_driver] = " \
     CONFIG_OF=y \
 "
-
-RESIN_CONFIGS_append = " vmsplit"
-RESIN_CONFIGS[vmsplit] = " \
-    CONFIG_VMSPLIT_3G=y \
-"


### PR DESCRIPTION
While this makes it possible to run more containers on 32-bit RPi-s it makes the upper 256MB of memory unusable. We have tried to compensate with zram but that is not a suitable solution from a long-term perspective.