### PR TITLE
linux-kunbus: Do not add explicit root cmdline parameter

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus.bbappend
@@ -14,8 +14,8 @@ SRC_URI_append = " \
 "
 
 # Set console accordingly to build type
-DEBUG_CMDLINE = "dwc_otg.lpm_enable=0 console=tty1 root=LABEL=resin-rootA rootfstype=ext4 rootwait"
-PRODUCTION_CMDLINE = "dwc_otg.lpm_enable=0 console=null root=LABEL=resin-rootA rootfstype=ext4 rootwait vt.global_cursor_default=0"
+DEBUG_CMDLINE = "dwc_otg.lpm_enable=0 console=tty1 rootfstype=ext4 rootwait"
+PRODUCTION_CMDLINE = "dwc_otg.lpm_enable=0 console=null rootfstype=ext4 rootwait vt.global_cursor_default=0"
 CMDLINE = "${@bb.utils.contains('DISTRO_FEATURES','development-image',"${DEBUG_CMDLINE}","${PRODUCTION_CMDLINE}",d)}"
 CMDLINE_DEBUG = ""
 


### PR DESCRIPTION
This gets added by u-boot in the form of root=UUID=

Changelog-entry: Remove explicit root cmdline parameter from the kernel recipe
Signed-off-by: Florin Sarbu <florin@balena.io>