### PR TITLE
recipes-kernel: remove rootfstype=ext4

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus.bbappend
@@ -5,8 +5,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_append = " file://0001-rtc-hctosys-Correctly-guard-hw-clock-polling-code.patch"
 
 # Set console accordingly to build type
-DEBUG_CMDLINE = "dwc_otg.lpm_enable=0 console=tty1 rootfstype=ext4 rootwait"
-PRODUCTION_CMDLINE = "dwc_otg.lpm_enable=0 console=null rootfstype=ext4 rootwait vt.global_cursor_default=0"
+DEBUG_CMDLINE = "dwc_otg.lpm_enable=0 console=tty1 rootwait"
+PRODUCTION_CMDLINE = "dwc_otg.lpm_enable=0 console=null rootwait vt.global_cursor_default=0"
 CMDLINE = "${@bb.utils.contains('DISTRO_FEATURES','development-image',"${DEBUG_CMDLINE}","${PRODUCTION_CMDLINE}",d)}"
 CMDLINE_DEBUG = ""
 

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
@@ -30,8 +30,8 @@ LINUX_VERSION = "4.19.118"
 SRCREV = "fe2c7bf4cad4641dfb6f12712755515ab15815ca"
 
 # Set console accordingly to build type
-DEBUG_CMDLINE = "dwc_otg.lpm_enable=0 console=tty1 console=serial0,115200 rootfstype=ext4 rootwait"
-PRODUCTION_CMDLINE = "dwc_otg.lpm_enable=0 console=null rootfstype=ext4 rootwait vt.global_cursor_default=0"
+DEBUG_CMDLINE = "dwc_otg.lpm_enable=0 console=tty1 console=serial0,115200 rootwait"
+PRODUCTION_CMDLINE = "dwc_otg.lpm_enable=0 console=null rootwait vt.global_cursor_default=0"
 CMDLINE = "${@bb.utils.contains('DISTRO_FEATURES','development-image',"${DEBUG_CMDLINE}","${PRODUCTION_CMDLINE}",d)}"
 CMDLINE_DEBUG = ""
 

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
@@ -31,8 +31,8 @@ SRC_URI_append_rt-rpi-300 = " \
 "
 
 # Set console accordingly to build type
-DEBUG_CMDLINE = "dwc_otg.lpm_enable=0 console=tty1 console=serial0,115200 rootfstype=ext4 rootwait"
-PRODUCTION_CMDLINE = "dwc_otg.lpm_enable=0 console=null rootfstype=ext4 rootwait vt.global_cursor_default=0"
+DEBUG_CMDLINE = "dwc_otg.lpm_enable=0 console=tty1 console=serial0,115200 rootwait"
+PRODUCTION_CMDLINE = "dwc_otg.lpm_enable=0 console=null rootwait vt.global_cursor_default=0"
 CMDLINE = "${@bb.utils.contains('DISTRO_FEATURES','development-image',"${DEBUG_CMDLINE}","${PRODUCTION_CMDLINE}",d)}"
 CMDLINE_DEBUG = ""
 


### PR DESCRIPTION
This boot parameter specifies that the rootfs is ext4, which can be
autodetected, and makes booting with other filesystems fail.

Remove the flag to improve compatiblity with alternative filesystems.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>