### PR TITLE
linux-raspberry: Enable cgroups memory by default

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
@@ -34,6 +34,9 @@ SRC_URI_append_rt-rpi-300 = " \
 DEBUG_CMDLINE = "dwc_otg.lpm_enable=0 console=tty1 console=serial0,115200 rootfstype=ext4 rootwait"
 PRODUCTION_CMDLINE = "dwc_otg.lpm_enable=0 console=null rootfstype=ext4 rootwait vt.global_cursor_default=0"
 CMDLINE = "${@bb.utils.contains('DISTRO_FEATURES','development-image',"${DEBUG_CMDLINE}","${PRODUCTION_CMDLINE}",d)}"
+
+# See https://github.com/raspberrypi/linux/commit/9b0efcc1ec497b2985c6aaa60cd97f0d2d96d203
+CMDLINE_append = " cgroup_enable=memory"
 CMDLINE_DEBUG = ""
 
 RESIN_CONFIGS_append = " fbtft"


### PR DESCRIPTION
The upstream kernel has disabled cgroups memory support by default and
made it a kernel argument in order to save memory;

https://github.com/raspberrypi/linux/commit/9b0efcc1ec497b2985c6aaa60cd97f0d2d96d203

BalenaOS requires this setting to be enabled.

Fixes https://github.com/balena-os/balena-raspberrypi/issues/574

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>