### PR TITLE
add balena-fin overlay for raspberrypi3-64

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -139,6 +139,8 @@ KERNEL_DEVICETREE_append = " \
 KERNEL_DEVICETREE_append_fincm3 = " overlays/balena-fin.dtbo"
 KERNEL_DEVICETREE_append_fincm3 = " overlays/spyfly.dtbo"
 
+KERNEL_DEVICETREE_append_raspberrypi3-64 = " overlays/balena-fin.dtbo"
+
 KERNEL_DEVICETREE_append_raspberrypi4-64 = " \
     overlays/i2c3.dtbo \
     overlays/i2c4.dtbo \


### PR DESCRIPTION
add balena-fin overlay to the 64 bit raspberry pi 3 image

Change-type: patch
Signed-off-by: Aaron Shaw <aaron@balena.io>