### PR TITLE
layers: update device tree blob list

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -15,44 +15,75 @@ LAYERSERIES_COMPAT_balena-raspberrypi = "warrior"
 # the ones already defined in meta-raspberrypi/conf/machine/include/rpi-base.inc.
 # They have been renamed to match rpi-base.inc.
 KERNEL_DEVICETREE_append = " \
+    overlays/act-led.dtbo \
+    overlays/adafruit18.dtbo \
     overlays/adau1977-adc.dtbo \
     overlays/adau7002-simple.dtbo \
     overlays/ads1015.dtbo \
     overlays/ads1115.dtbo \
     overlays/ads7846.dtbo \
+    overlays/adv7282m.dtbo \
+    overlays/adv7282m.dtbo \
     overlays/akkordion-iqdacplus.dtbo \
     overlays/allo-boss-dac-pcm512x-audio.dtbo \
+    overlays/allo-boss2-dac-audio.dtbo \
     overlays/allo-digione.dtbo \
+    overlays/allo-katana-dac-audio.dtbo \
     overlays/allo-piano-dac-pcm512x-audio.dtbo \
     overlays/allo-piano-dac-plus-pcm512x-audio.dtbo \
+    overlays/anyspi.dtbo \
+    overlays/apds9960.dtbo \
+    overlays/applepi-dac.dtbo \
     overlays/at86rf233.dtbo \
     overlays/audioinjector-addons.dtbo \
+    overlays/audioinjector-isolated-soundcard.dtbo \
+    overlays/audioinjector-ultra.dtbo \
     overlays/audioinjector-wm8731-audio.dtbo \
+    overlays/audiosense-pi.dtbo \
     overlays/audremap.dtbo \
+    overlays/balena-fin.dtbo \
     overlays/bmp085_i2c-sensor.dtbo \
+    overlays/cma.dtbo \
     overlays/dht11.dtbo \
     overlays/dionaudio-loco.dtbo \
     overlays/dionaudio-loco-v2.dtbo \
+    overlays/disable-bt.dtbo \
+    overlays/disable-wifi.dtbo \
     overlays/dpi18.dtbo \
     overlays/dpi24.dtbo \
+    overlays/draws.dtbo \
     overlays/dwc2.dtbo \
     overlays/dwc-otg.dtbo \
     overlays/enc28j60.dtbo \
     overlays/enc28j60-spi2.dtbo \
+    overlays/exc3000.dtbo \
     overlays/fe-pi-audio.dtbo \
+    overlays/fsm-demo.dtbo \
+    overlays/ghost-amp.dtbo \
     overlays/goodix.dtbo \
     overlays/googlevoicehat-soundcard.dtbo \
-    overlays/gpio-ir.dtbo \
-    overlays/gpio-ir-tx.dtbo \
+    overlays/gpio-fan.dtbo \
+    overlays/gpio-key.dtbo \
+    overlays/gpio-no-bank0-irq.dtbo \
+    overlays/gpio-no-irq.dtbo \
     overlays/gpio-poweroff.dtbo \
     overlays/gpio-shutdown.dtbo \
+    overlays/hd44780-lcd.dtbo \
+    overlays/hdmi-backlight-hwhack-gpio.dtbo \
+    overlays/hifiberry-dacplusadc.dtbo \
+    overlays/hifiberry-dacplusadcpro.dtbo \
+    overlays/hifiberry-dacplusdsp.dtbo \
+    overlays/hifiberry-dacplushd.dtbo \
     overlays/hifiberry-digi-pro.dtbo \
+    overlays/highperi.dtbo \
     overlays/hy28a.dtbo \
+    overlays/hy28b-2017.dtbo \
     overlays/hy28b.dtbo \
     overlays/hyperpixel4-pi3.dtbo \
     overlays/hyperpixel4-pi4.dtbo \
     overlays/hyperpixel4-square-pi3.dtbo \
     overlays/hyperpixel4-square-pi4.dtbo \
+    overlays/i-sabre-q2m.dtbo \
     overlays/i2c0-bcm2708.dtbo \
     overlays/i2c0.dtbo \
     overlays/i2c1-bcm2708.dtbo \
@@ -63,28 +94,60 @@ KERNEL_DEVICETREE_append = " \
     overlays/i2c-pwm-pca9685a.dtbo \
     overlays/i2c-rtc-gpio.dtbo \
     overlays/i2c-sensor.dtbo \
+    overlays/i2c3.dtbo \
+    overlays/i2c4.dtbo \
+    overlays/i2c5.dtbo \
+    overlays/i2c6.dtbo \
     overlays/i2s-gpio28-31.dtbo \
+    overlays/ilitek251x.dtbo \
+    overlays/imx290.dtbo \
+    overlays/imx290_327.dtbo \
+    overlays/imx477.dtbo \
+    overlays/iqaudio-codec.dtbo \
     overlays/iqaudio-digi-wm8804-audio.dtbo \
+    overlays/irs1125.dtbo \
+    overlays/jedec-spi-nor.dtbo \
+    overlays/justboom-both.dtbo \
     overlays/justboom-dac.dtbo \
     overlays/justboom-digi.dtbo \
+    overlays/ltc294x.dtbo \
+    overlays/max98357a.dtbo \
+    overlays/maxtherm.dtbo \
+    overlays/mbed-dac.dtbo \
     overlays/mcp23017.dtbo \
     overlays/mcp23s17.dtbo \
     overlays/mcp2515-can0.dtbo \
     overlays/mcp2515-can1.dtbo \
+    overlays/mcp251xfd.dtbo \
     overlays/mcp3008.dtbo \
+    overlays/mcp3202.dtbo \
+    overlays/mcp342x.dtbo \
+    overlays/media-center.dtbo \
+    overlays/merus-amp.dtbo \
     overlays/midi-uart0.dtbo \
     overlays/midi-uart1.dtbo \
+    overlays/miniuart-bt.dtbo \
     overlays/mmc.dtbo \
     overlays/mpu6050.dtbo \
     overlays/mz61581.dtbo \
+    overlays/ov5647.dtbo \
+    overlays/ov7251.dtbo \
+    overlays/ov9281.dtbo \
+    overlays/overlay_map.dtbo \
     overlays/papirus.dtbo \
+    overlays/pca953x.dtbo \
     overlays/pi3-act-led.dtbo \
     overlays/pi3-disable-wifi.dtbo \
+    overlays/pibell.dtbo \
+    overlays/pifacedigital.dtbo \
+    overlays/pifi-40.dtbo \
+    overlays/piglow.dtbo \
     overlays/piscreen2r.dtbo \
     overlays/piscreen.dtbo \
     overlays/pisound.dtbo \
     overlays/pitft28-capacitive.dtbo \
     overlays/pwm-2chan.dtbo \
+    overlays/pwn-ir-tx.dtbo \
     overlays/pwm.dtbo \
     overlays/qca7000.dtbo \
     overlays/rotary-encoder.dtbo \
@@ -95,15 +158,22 @@ KERNEL_DEVICETREE_append = " \
     overlays/rpi-proto.dtbo \
     overlays/rpi-sense.dtbo \
     overlays/rpi-tv.dtbo \
+    overlays/rpivid-v4l2.dtbo \
     overlays/rra-digidac1-wm8741-audio.dtbo \
+    overlays/sainsmart18.dtbo \
     overlays/sc16is750-i2c.dtbo \
+    overlays/sc16is752-i2c.dtbo \
+    overlays/sc16is752-spi0.dtbo \
     overlays/sc16is752-spi1.dtbo \
     overlays/sdhost.dtbo \
     overlays/sdio.dtbo \
     overlays/sdtweak.dtbo \
+    overlays/sh1106-spi.dtbo \
     overlays/smi-dev.dtbo \
     overlays/smi.dtbo \
     overlays/smi-nand.dtbo \
+    overlays/spi0-1cs.dtbo \
+    overlays/spi0-2cs.dtbo \
     overlays/spi0-cs.dtbo \
     overlays/spi0-hw-cs.dtbo \
     overlays/spi1-1cs.dtbo \
@@ -121,7 +191,15 @@ KERNEL_DEVICETREE_append = " \
     overlays/spi6-1cs.dtbo \
     overlays/spi6-2cs.dtbo \
     overlays/spi-gpio35-39.dtbo \
+    overlays/spi-gpio40-45.dtbo \
     overlays/spi-rtc.dtbo \
+    overlays/ssd1306.dtbo \
+    overlays/ssd1306-spi.dtbo \
+    overlays/ssd1351-spi.dtbo \
+    overlays/superaudioboard.dtbo \
+    overlays/sx150x.dtbo \
+    overlays/tc358743-audio.dtbo \
+    overlays/tc358743.dtbo \
     overlays/tinylcd35.dtbo \
     overlays/tpm-slb9670.dtbo \
     overlays/uart0.dtbo \
@@ -130,10 +208,17 @@ KERNEL_DEVICETREE_append = " \
     overlays/uart3.dtbo \
     overlays/uart4.dtbo \
     overlays/uart5.dtbo \
+    overlays/udrc.dtbo \
+    overlays/upstream.dtbo \
+    overlays/upstream-pi4.dtbo \
     overlays/vc4-fkms-v3d.dtbo \
+    overlays/vc4-kms-kippah-7inch.dtbo \
+    overlays/vc4-kms-v3d-pi4.dtbo \
     overlays/vga666.dtbo \
+    overlays/w5500.dtbo \
     overlays/waveshare-sim7600.dtbo \
     overlays/wittypi.dtbo \
+    overlays/wm8960-soundcard.dtbo \
 "
 
 KERNEL_DEVICETREE_append_fincm3 = " overlays/balena-fin.dtbo"


### PR DESCRIPTION
Add new device tree blobs to the list to bring in support for new hardware such as merus-amp and more. From https://github.com/raspberrypi/linux/tree/rpi-5.4.y/arch/arm/boot/dts/overlays

Change-type: minor
Signed-off-by: Aaron Shaw <aaron@balena.io>