### PR TITLE
u-boot: Avoid lockup on dev images with uart disabled

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/serial_pl01x-Add-retry-limit-when-writing-to-uart-co.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/serial_pl01x-Add-retry-limit-when-writing-to-uart-co.patch
@@ -1,0 +1,44 @@
+From 7e1061c2c5bfc13bcd14ea80f41793efc2859d66 Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Tue, 26 Jan 2021 11:47:49 +0100
+Subject: [PATCH] serial_pl01x: Add retry limit when writing to uart console
+
+The newer 2020.x u-boot waits indefinitely to write
+to the console if uart has been disabled or is incorrectly
+configured. Let's add a retry timeout and give up if impossible
+to put chars on the line, like we did for bcm283x_mu.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ drivers/serial/serial_pl01x.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/serial/serial_pl01x.c b/drivers/serial/serial_pl01x.c
+index 6e5d81ce34..22d985f96c 100644
+--- a/drivers/serial/serial_pl01x.c
++++ b/drivers/serial/serial_pl01x.c
+@@ -34,11 +34,18 @@ static struct pl01x_regs *base_regs __attribute__ ((section(".data")));
+ 
+ #endif
+ 
++static uint16_t putc_retry;
+ static int pl01x_putc(struct pl01x_regs *regs, char c)
+ {
+ 	/* Wait until there is space in the FIFO */
+-	if (readl(&regs->fr) & UART_PL01x_FR_TXFF)
+-		return -EAGAIN;
++	if (readl(&regs->fr) & UART_PL01x_FR_TXFF) {
++		if (++putc_retry) {
++			return -EAGAIN;
++		} else {
++			/* Couldn't write for too long, drop char */
++			return 0;
++		}
++	}
+ 
+ 	/* Send the character */
+ 	writel(c, &regs->dr);
+-- 
+2.17.1
+

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -24,8 +24,10 @@ SRC_URI += " \
 
 # Disable flasher check since it starts usb unnecessarily
 # and we don't generate flasher images for any of the RPIs.
+# Also, add a retry count limit for the uart on u-boot 2020.x
 SRC_URI_append = " \
     file://0001-rpi-Disable-image-flasher-check.patch \
+    file://serial_pl01x-Add-retry-limit-when-writing-to-uart-co.patch \
 "
 
 RESIN_UBOOT_DEVICE_TYPES_append = " usb"


### PR DESCRIPTION
u-boot 2020.x switched to using the pl_01x driver which
locks up too if the uart is incorrecty configured
or is disabled from config.txt. We add a retry count
to avoid locking forever when serial isn't available.

Changelog-entry: u-boot: Avoid lockup on dev image with uart disabled
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Addresses https://github.com/balena-os/balena-raspberrypi/issues/588