### PR TITLE
resin-image: Fix overlay-map.dtb deploy location

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/images/resin-image.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/images/resin-image.bbappend
@@ -33,6 +33,10 @@ python overlay_dtbs_handler () {
 
             for dtb in root_dtbs.split():
                 dtb = os.path.basename(dtb)
+                # newer kernels (5.4 onward) introduce overlay_map.dtb which needs to be deployed in the overlays directory
+                if dtb == 'overlay_map.dtb':
+                    resin_boot_partition_files += "\t%s:/overlays/%s" % (dtb, dtb)
+                    continue
                 resin_boot_partition_files += "\t%s:/%s" % (dtb, dtb)
 
             for dtb in overlay_dtbs.split():


### PR DESCRIPTION
Starting with kernel 5.4 a new device tree blob called overlay_map.dtb
was rolled out. This file needs to be placed in the overlays directory.

For details see
https://www.raspberrypi.org/documentation/configuration/device-tree.md

Changelog-entry: Fix overlay-map.dtb deploy location
Signed-off-by: Florin Sarbu <florin@balena.io>