### PR TITLE
Add tpm-slb9670-tis-spi DT overlay

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -188,6 +188,7 @@ KERNEL_DEVICETREE_append = " \
     overlays/tc358743.dtbo \
     overlays/tinylcd35.dtbo \
     overlays/tpm-slb9670.dtbo \
+    overlays/tpm-slb9670-tis-spi.dtbo \
     overlays/uart0.dtbo \
     overlays/uart1.dtbo \
     overlays/uart2.dtbo \
@@ -219,6 +220,7 @@ KERNEL_DEVICETREE_append_raspberrypi4-64 = " overlays/spi-gpio40-45.dtbo"
 KERNEL_DEVICETREE_remove_revpi = "overlays/i2c0.dtbo"
 KERNEL_DEVICETREE_remove_revpi = "overlays/i2c1.dtbo"
 KERNEL_DEVICETREE_remove_revpi = "overlays/tpm-slb9670.dtbo"
+KERNEL_DEVICETREE_remove_revpi = "overlays/tpm-slb9670-tis-spi.dtbo"
 KERNEL_DEVICETREE_remove_revpi = "overlays/spi3-1cs.dtbo"
 KERNEL_DEVICETREE_remove_revpi = "overlays/spi3-2cs.dtbo"
 KERNEL_DEVICETREE_remove_revpi = "overlays/spi4-1cs.dtbo"

--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -299,3 +299,5 @@ UBOOT_MACHINE_raspberrypi4-64 = "rpi_arm64_defconfig"
 # in the rootfs, raspbian doesn't either. Including it
 # breaks usb boot in u-boot, as well as the usb2.0 port
 # and the mouse support in the kernel.
+
+RPI_KERNEL_DEVICETREE_append_raspberrypi3-64 = " broadcom/bcm2710-rpi-cm3.dtb"

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0001-Add-tpm-slb9670-tis-spi-DT-overlay.patch
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0001-Add-tpm-slb9670-tis-spi-DT-overlay.patch
@@ -1,0 +1,54 @@
+From d211b4e01d2621ce03854f722f8db5acfe457ae0 Mon Sep 17 00:00:00 2001
+From: Michal Toman <michalt@balena.io>
+Date: Mon, 1 Feb 2021 16:05:38 +0100
+Subject: [PATCH] Add tpm-slb9670-tis-spi DT overlay
+
+Signed-off-by: Michal Toman <michalt@balena.io>
+---
+ arch/arm/boot/dts/overlays/Makefile           |  1 +
+ .../overlays/tpm-slb9670-tis-spi-overlay.dts  | 21 +++++++++++++++++++
+ 2 files changed, 22 insertions(+)
+ create mode 100644 arch/arm/boot/dts/overlays/tpm-slb9670-tis-spi-overlay.dts
+
+diff --git a/arch/arm/boot/dts/overlays/Makefile b/arch/arm/boot/dts/overlays/Makefile
+index d8a3677b583e..696b5789e64c 100644
+--- a/arch/arm/boot/dts/overlays/Makefile
++++ b/arch/arm/boot/dts/overlays/Makefile
+@@ -194,6 +194,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
+ 	tc358743-audio.dtbo \
+ 	tinylcd35.dtbo \
+ 	tpm-slb9670.dtbo \
++	tpm-slb9670-tis-spi.dtbo \
+ 	uart0.dtbo \
+ 	uart1.dtbo \
+ 	uart2.dtbo \
+diff --git a/arch/arm/boot/dts/overlays/tpm-slb9670-tis-spi-overlay.dts b/arch/arm/boot/dts/overlays/tpm-slb9670-tis-spi-overlay.dts
+new file mode 100644
+index 000000000000..e43f8cd248ec
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/tpm-slb9670-tis-spi-overlay.dts
+@@ -0,0 +1,21 @@
++/*
++ * Device Tree overlay for the Infineon SLB9670 Trusted Platform Module
++ * that uses the tpm_tis-spi driver instead of the original slb9670.
++ * This depends on the tpm-slb9670 overlay being applied prior to this one.
++ */
++
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "brcm,bcm2835";
++
++	fragment@0 {
++		target = <&spi0>;
++		__overlay__ {
++			slb9670: slb9670@1 {
++				compatible = "tcg,tpm_tis-spi";
++			};
++		};
++	};
++};
+-- 
+2.26.2
+

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
@@ -13,6 +13,7 @@ SRC_URI_append = " \
 	file://0001-Add-npe-x500-m3-overlay.patch \
 	file://0006-overlays-Add-Hyperpixel4-overlays.patch \
 	file://0001-waveshare-sim7600-Add-dtbo-for-this-modem.patch \
+	file://0001-Add-tpm-slb9670-tis-spi-DT-overlay.patch \
 "
 
 # We apply this fix for Pi3 and Pi3-64 (which overrides Pi3)

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
@@ -20,6 +20,7 @@ SRC_URI_append = " \
 	file://0001-Add-npe-x500-m3-overlay.patch \
 	file://0006-overlays-Add-Hyperpixel4-overlays.patch \
 	file://0001-waveshare-sim7600-Add-dtbo-for-this-modem.patch \
+	file://0001-Add-tpm-slb9670-tis-spi-DT-overlay.patch \
 "
 
 SRC_URI_append_raspberrypi4-64 = " \


### PR DESCRIPTION
We do ship a tpm-slb9670 DT overlay that loads the default slb9670
driver but there is HW that needs tis-spi driver instead.
This patch adds an overlay that will load the tis-spi driver
when applied.

Signed-off-by: Michal Toman <michalt@balena.io>