### PR TITLE
linux-raspberrypi: Do not use VMSPLIT_3G on 5.4 kernel

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
@@ -178,11 +178,6 @@ RESIN_CONFIGS_DEPS[sd8787_pwrseq_driver] = " \
     CONFIG_OF=y \
 "
 
-RESIN_CONFIGS_append = " vmsplit"
-RESIN_CONFIGS_DEPS[vmsplit] = " \
-    CONFIG_VMSPLIT_3G=y \
-"
-
 RESIN_CONFIGS_append = " serial_8250"
 RESIN_CONFIGS[serial_8250] = " \
     CONFIG_SERIAL_8250=y \


### PR DESCRIPTION
This has been rolled back from 4.19 but has been copied to 5.4
inbetween and overlooked, we do not want to use it.

Changelog-entry: Use 2GB kernel / 2GB userspace memory split on 5.4 kernels
Change-type: minor
Signed-off-by: Michal Toman <michalt@balena.io>