### PR TITLE
meta-balena-raspberrypi/linux: fix ethernet cable detection

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0009-network-lan78xx-interrupt.patch
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0009-network-lan78xx-interrupt.patch
@@ -1,0 +1,34 @@
+From 2cc41cfc79323d90b7fd8f28b22e77db2a0c3360 Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.com>
+Date: Tue, 15 Dec 2020 16:38:37 +0000
+Subject: [PATCH] net: lan78xx: Ack pending PHY ints when resetting
+
+lan78xx_link_reset explicitly clears the MAC's view of the PHY's IRQ
+status. In doing so it potentially leaves the PHY with a pending
+interrupt that will never be acknowledged, at which point no further
+interrupts will be generated.
+
+Avoid the problem by acknowledging any pending PHY interrupt after
+clearing the MAC's status bit.
+
+See: https://github.com/raspberrypi/linux/issues/2937
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.com>
+---
+ drivers/net/usb/lan78xx.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/net/usb/lan78xx.c b/drivers/net/usb/lan78xx.c
+index 58f5b90f11d46..3cf5ad0bf0c19 100644
+--- a/drivers/net/usb/lan78xx.c
++++ b/drivers/net/usb/lan78xx.c
+@@ -1181,6 +1181,9 @@ static int lan78xx_link_reset(struct lan78xx_net *dev)
+ 	if (unlikely(ret < 0))
+ 		return -EIO;
+ 
++	/* Acknowledge any pending PHY interrupt, lest it be the last */
++	phy_read(phydev, LAN88XX_INT_STS);
++
+ 	phy_read_status(phydev);
+ 
+ 	if (!phydev->link && dev->link_on) {

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
@@ -21,6 +21,7 @@ SRC_URI_append = " \
 	file://0006-overlays-Add-Hyperpixel4-overlays.patch \
 	file://0001-waveshare-sim7600-Add-dtbo-for-this-modem.patch \
 	file://0001-Add-tpm-slb9670-tis-spi-DT-overlay.patch \
+	file://0009-network-lan78xx-interrupt.patch \
 "
 
 SRC_URI_append_raspberrypi4-64 = " \


### PR DESCRIPTION
Ethernet cable connect/disconnect events are not detected when a device is booted with the ethernet cable already connected.

This is a known issue: https://github.com/raspberrypi/linux/issues/2937

This commit applies an upstream patch that is already in the raspberrypi-linux rpi-5.4.y and rpi-5.10.y branches.

Tested on a Raspberry Pi 3 B+ with balenaOS v2.69.1+rev2.

Change-type: patch
Connects-to: #605
Changelog-entry: meta-balena-raspberrypi/linux: fix ethernet cable detection
Signed-off-by: Mark Corbin <mark@balena.io>