### PR TITLE
balena-raspberrypi: Rename resin image types to balena

### DIFF
--- a/fincm3.coffee
+++ b/fincm3.coffee
@@ -32,10 +32,10 @@ module.exports =
 
 	yocto:
 		machine: 'fincm3'
-		image: 'resin-image'
-		fstype: 'resinos-img'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-fincm3.resinos-img'
+		deployArtifact: 'balena-image-fincm3.balenaos-img'
 		compressed: true
 
 	configuration:

--- a/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
+++ b/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
@@ -55,7 +55,7 @@ RPI_USE_U_BOOT = "1"
 #SUPERVISOR_TAG ?= "master"
 
 # Compress final raw image
-#RESIN_RAW_IMG_COMPRESSION ?= "xz"
+#BALENA_RAW_IMG_COMPRESSION ?= "xz"
 
 # Parallelism Options
 BB_NUMBER_THREADS ?= "${@oe.utils.cpu_count()}"

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-Integrate-machine-independent-resin-environment-conf.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-Integrate-machine-independent-resin-environment-conf.patch
@@ -30,7 +30,7 @@ index 54d8124..44b7523 100644
  const uchar default_environment[] = {
  #endif
  #ifndef CONFIG_USE_DEFAULT_ENV_FILE
-+    RESIN_ENV
++    BALENA_ENV
  #ifdef	CONFIG_ENV_CALLBACK_LIST_DEFAULT
  	ENV_CALLBACK_VAR "=" CONFIG_ENV_CALLBACK_LIST_DEFAULT "\0"
  #endif

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -30,7 +30,7 @@ SRC_URI_append = " \
     file://serial_pl01x-Add-retry-limit-when-writing-to-uart-co.patch \
 "
 
-RESIN_UBOOT_DEVICE_TYPES_append = " usb"
+BALENA_UBOOT_DEVICE_TYPES_append = " usb"
 
 SRCREV_raspberrypi4-64 = "52ba373b7825e9feab8357065155cf43dfe2f4ff"
 LIC_FILES_CHKSUM_raspberrypi4-64 = " file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"

--- a/layers/meta-balena-raspberrypi/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/images/balena-image.bbappend
@@ -3,30 +3,30 @@
 # https://www.raspberrypi.org/documentation/hardware/computemodule/cm-emmc-flashing.md
 BALENA_BOOT_FAT32 = "1"
 
-IMAGE_FSTYPES_append_rpi = " resinos-img"
+IMAGE_FSTYPES_append_rpi = " balenaos-img"
 
 # Kernel image name is different on Raspberry Pi 1/2/3-64bit
 SDIMG_KERNELIMAGE_raspberrypi  ?= "kernel.img"
 SDIMG_KERNELIMAGE_raspberrypi2 ?= "kernel7.img"
 SDIMG_KERNELIMAGE_raspberrypi3-64 ?= "kernel8.img"
 
-# Customize resinos-img
-RESIN_IMAGE_BOOTLOADER_rpi = "bootfiles"
-RESIN_BOOT_PARTITION_FILES_rpi = " \
+# Customize balenaos-img
+BALENA_IMAGE_BOOTLOADER_rpi = "bootfiles"
+BALENA_BOOT_PARTITION_FILES_rpi = " \
     u-boot.bin:/${SDIMG_KERNELIMAGE} \
     boot.scr:/boot.scr \
     bootfiles:/ \
     "
 
-RESIN_BOOT_PARTITION_FILES_append_revpi-core-3 = " revpi-core-dt-blob-overlay.dtb:/dt-blob.bin"
+BALENA_BOOT_PARTITION_FILES_append_revpi-core-3 = " revpi-core-dt-blob-overlay.dtb:/dt-blob.bin"
 
-RESIN_BOOT_PARTITION_FILES_append_revpi-connect = " revpi-connect-dt-blob-overlay.dtb:/dt-blob.bin"
+BALENA_BOOT_PARTITION_FILES_append_revpi-connect = " revpi-connect-dt-blob-overlay.dtb:/dt-blob.bin"
 
 python overlay_dtbs_handler () {
     # Add all the dtb files programatically
     for soc_fam in d.getVar('SOC_FAMILY', True).split(':'):
         if soc_fam == 'rpi':
-            resin_boot_partition_files = d.getVar('RESIN_BOOT_PARTITION_FILES', True)
+            resin_boot_partition_files = d.getVar('BALENA_BOOT_PARTITION_FILES', True)
 
             overlay_dtbs = split_overlays(d, 0)
             root_dtbs = split_overlays(d, 1)
@@ -43,7 +43,7 @@ python overlay_dtbs_handler () {
                 dtb = os.path.basename(dtb)
                 resin_boot_partition_files += "\t%s:/overlays/%s" % (dtb, dtb)
 
-            d.setVar('RESIN_BOOT_PARTITION_FILES', resin_boot_partition_files)
+            d.setVar('BALENA_BOOT_PARTITION_FILES', resin_boot_partition_files)
 
             break
 }

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus.bbappend
@@ -10,8 +10,8 @@ PRODUCTION_CMDLINE = "dwc_otg.lpm_enable=0 console=null rootwait vt.global_curso
 CMDLINE = "${@bb.utils.contains('DISTRO_FEATURES','development-image',"${DEBUG_CMDLINE}","${PRODUCTION_CMDLINE}",d)}"
 CMDLINE_DEBUG = ""
 
-RESIN_CONFIGS_append = " fbtft"
-RESIN_CONFIGS[fbtft] = " \
+BALENA_CONFIGS_append = " fbtft"
+BALENA_CONFIGS[fbtft] = " \
     CONFIG_STAGING=y \
     CONFIG_FB_TFT=m \
     CONFIG_FB_TFT_AGM1264K_FL=m \
@@ -44,8 +44,8 @@ RESIN_CONFIGS[fbtft] = " \
     CONFIG_FB_TFT_FBTFT_DEVICE=m \
     "
 
-RESIN_CONFIGS_append = " pca955_gpio_expander"
-RESIN_CONFIGS[pca955_gpio_expander] = " \
+BALENA_CONFIGS_append = " pca955_gpio_expander"
+BALENA_CONFIGS[pca955_gpio_expander] = " \
     CONFIG_GPIO_PCA953X=y \
     CONFIG_GPIO_PCA953X_IRQ=y \
     "
@@ -53,13 +53,13 @@ RESIN_CONFIGS[pca955_gpio_expander] = " \
 KERNEL_MODULE_PROBECONF += "rtl8192cu"
 module_conf_rtl8192cu = "blacklist rtl8192cu"
 
-RESIN_CONFIGS_append = " preempt_rt"
-RESIN_CONFIGS[preempt_rt] = " \
+BALENA_CONFIGS_append = " preempt_rt"
+BALENA_CONFIGS[preempt_rt] = " \
     CONFIG_PREEMPT_RT_FULL=y \
 "
 
-RESIN_CONFIGS_append = " revpi_expansion_modules_support"
-RESIN_CONFIGS[revpi_expansion_modules_support] = " \
+BALENA_CONFIGS_append = " revpi_expansion_modules_support"
+BALENA_CONFIGS[revpi_expansion_modules_support] = " \
     CONFIG_KS8851=m \
     CONFIG_GPIO_74X164=m \
     CONFIG_GPIO_MAX3191X=m \

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.19.bbappend
@@ -36,8 +36,8 @@ PRODUCTION_CMDLINE = "dwc_otg.lpm_enable=0 console=null rootwait vt.global_curso
 CMDLINE = "${@bb.utils.contains('DISTRO_FEATURES','development-image',"${DEBUG_CMDLINE}","${PRODUCTION_CMDLINE}",d)}"
 CMDLINE_DEBUG = ""
 
-RESIN_CONFIGS_append = " fbtft"
-RESIN_CONFIGS[fbtft] = " \
+BALENA_CONFIGS_append = " fbtft"
+BALENA_CONFIGS[fbtft] = " \
     CONFIG_STAGING=y \
     CONFIG_FB_TFT=m \
     CONFIG_FB_TFT_AGM1264K_FL=m \
@@ -70,8 +70,8 @@ RESIN_CONFIGS[fbtft] = " \
     CONFIG_FB_TFT_FBTFT_DEVICE=m \
     "
 
-RESIN_CONFIGS_append = " pca955_gpio_expander"
-RESIN_CONFIGS[pca955_gpio_expander] = " \
+BALENA_CONFIGS_append = " pca955_gpio_expander"
+BALENA_CONFIGS[pca955_gpio_expander] = " \
     CONFIG_GPIO_PCA953X=y \
     CONFIG_GPIO_PCA953X_IRQ=y \
     "
@@ -80,90 +80,90 @@ KERNEL_MODULE_PROBECONF += "rtl8192cu"
 module_conf_rtl8192cu = "blacklist rtl8192cu"
 
 # requested by customer (support for Kontron PLD devices)
-RESIN_CONFIGS_append = " gpio_i2c_kempld"
-RESIN_CONFIGS_DEPS[gpio_i2c_kempld] = " \
+BALENA_CONFIGS_append = " gpio_i2c_kempld"
+BALENA_CONFIGS_DEPS[gpio_i2c_kempld] = " \
     CONFIG_GPIOLIB=y \
     CONFIG_I2C=y \
     CONFIG_HAS_IOMEM=y \
     CONFIG_MFD_KEMPLD=m \
 "
-RESIN_CONFIGS[gpio_i2c_kempld] = " \
+BALENA_CONFIGS[gpio_i2c_kempld] = " \
     CONFIG_GPIO_KEMPLD=m \
     CONFIG_I2C_KEMPLD=m \
 "
 
 # make sure watchdog gets enabled no matter of the BSP changes
-RESIN_CONFIGS_append = " rpi_watchdog"
-RESIN_CONFIGS_DEPS[rpi_watchdog] = " \
+BALENA_CONFIGS_append = " rpi_watchdog"
+BALENA_CONFIGS_DEPS[rpi_watchdog] = " \
     CONFIG_WATCHDOG=y \
 "
-RESIN_CONFIGS[rpi_watchdog] = " \
+BALENA_CONFIGS[rpi_watchdog] = " \
     CONFIG_BCM2835_WDT=y \
 "
 
-RESIN_CONFIGS_append = " kvaser_usb_can_driver"
+BALENA_CONFIGS_append = " kvaser_usb_can_driver"
 
-RESIN_CONFIGS[kvaser_usb_can_driver] = " \
+BALENA_CONFIGS[kvaser_usb_can_driver] = " \
     CONFIG_CAN_KVASER_USB=m \
 "
 
-RESIN_CONFIGS_append = " mcp251x_can_driver"
+BALENA_CONFIGS_append = " mcp251x_can_driver"
 
-RESIN_CONFIGS[mcp251x_can_driver] = " \
+BALENA_CONFIGS[mcp251x_can_driver] = " \
     CONFIG_CAN_MCP251X=m \
 "
 
-RESIN_CONFIGS_DEPS[mcp251x_can_driver] = " \
+BALENA_CONFIGS_DEPS[mcp251x_can_driver] = " \
     CONFIG_SPI=y \
     CONFIG_HAS_DMA=y \
 "
 
-RESIN_CONFIGS_append = " can_calc_bittiming"
+BALENA_CONFIGS_append = " can_calc_bittiming"
 
-RESIN_CONFIGS[can_calc_bittiming] = " \
+BALENA_CONFIGS[can_calc_bittiming] = " \
 		CONFIG_CAN_CALC_BITTIMING=y \
 "
 
-RESIN_CONFIGS_DEPS[can_calc_bittiming] = " \
+BALENA_CONFIGS_DEPS[can_calc_bittiming] = " \
 		CONFIG_CAN_DEV=y \
 "
 
-RESIN_CONFIGS_append = " ds1307_rtc_driver"
+BALENA_CONFIGS_append = " ds1307_rtc_driver"
 
-RESIN_CONFIGS[ds1307_rtc_driver] = " \
+BALENA_CONFIGS[ds1307_rtc_driver] = " \
     CONFIG_RTC_DRV_DS1307=m \
 "
 
-RESIN_CONFIGS_DEPS[ds1307_rtc_driver] = " \
+BALENA_CONFIGS_DEPS[ds1307_rtc_driver] = " \
     CONFIG_I2C=y \
 "
 
-RESIN_CONFIGS_append = " sc16is7xx_serial_driver"
+BALENA_CONFIGS_append = " sc16is7xx_serial_driver"
 
-RESIN_CONFIGS[sc16is7xx_serial_driver] = " \
+BALENA_CONFIGS[sc16is7xx_serial_driver] = " \
     CONFIG_SERIAL_SC16IS7XX=m \
 "
 
-RESIN_CONFIGS_DEPS[sc16is7xx_serial_driver] = " \
+BALENA_CONFIGS_DEPS[sc16is7xx_serial_driver] = " \
     CONFIG_I2C=y \
 "
 
-RESIN_CONFIGS_append = " mcp3422_adc_driver"
+BALENA_CONFIGS_append = " mcp3422_adc_driver"
 
-RESIN_CONFIGS[mcp3422_adc_driver] = " \
+BALENA_CONFIGS[mcp3422_adc_driver] = " \
     CONFIG_MCP3422=m \
 "
 
-RESIN_CONFIGS_DEPS[mcp3422_adc_driver] = " \
+BALENA_CONFIGS_DEPS[mcp3422_adc_driver] = " \
     CONFIG_I2C=y \
 "
 
-RESIN_CONFIGS_append = " sd8787_pwrseq_driver"
+BALENA_CONFIGS_append = " sd8787_pwrseq_driver"
 
-RESIN_CONFIGS[sd8787_pwrseq_driver] = " \
+BALENA_CONFIGS[sd8787_pwrseq_driver] = " \
     CONFIG_PWRSEQ_SD8787=y \
 "
 
-RESIN_CONFIGS_DEPS[sd8787_pwrseq_driver] = " \
+BALENA_CONFIGS_DEPS[sd8787_pwrseq_driver] = " \
     CONFIG_OF=y \
 "

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
@@ -49,8 +49,8 @@ CMDLINE = "${@bb.utils.contains('DISTRO_FEATURES','development-image',"${DEBUG_C
 CMDLINE_append = " cgroup_enable=memory"
 CMDLINE_DEBUG = ""
 
-RESIN_CONFIGS_append = " fbtft"
-RESIN_CONFIGS[fbtft] = " \
+BALENA_CONFIGS_append = " fbtft"
+BALENA_CONFIGS[fbtft] = " \
     CONFIG_STAGING=y \
     CONFIG_FB_TFT=m \
     CONFIG_FB_TFT_AGM1264K_FL=m \
@@ -83,8 +83,8 @@ RESIN_CONFIGS[fbtft] = " \
     CONFIG_FB_TFT_FBTFT_DEVICE=m \
     "
 
-RESIN_CONFIGS_append = " pca955_gpio_expander"
-RESIN_CONFIGS[pca955_gpio_expander] = " \
+BALENA_CONFIGS_append = " pca955_gpio_expander"
+BALENA_CONFIGS[pca955_gpio_expander] = " \
     CONFIG_GPIO_PCA953X=y \
     CONFIG_GPIO_PCA953X_IRQ=y \
     "
@@ -93,96 +93,96 @@ KERNEL_MODULE_PROBECONF += "rtl8192cu"
 module_conf_rtl8192cu = "blacklist rtl8192cu"
 
 # requested by customer (support for Kontron PLD devices)
-RESIN_CONFIGS_append = " gpio_i2c_kempld"
-RESIN_CONFIGS_DEPS[gpio_i2c_kempld] = " \
+BALENA_CONFIGS_append = " gpio_i2c_kempld"
+BALENA_CONFIGS_DEPS[gpio_i2c_kempld] = " \
     CONFIG_GPIOLIB=y \
     CONFIG_I2C=y \
     CONFIG_HAS_IOMEM=y \
     CONFIG_MFD_KEMPLD=m \
 "
-RESIN_CONFIGS[gpio_i2c_kempld] = " \
+BALENA_CONFIGS[gpio_i2c_kempld] = " \
     CONFIG_GPIO_KEMPLD=m \
     CONFIG_I2C_KEMPLD=m \
 "
 
 # make sure watchdog gets enabled no matter of the BSP changes
-RESIN_CONFIGS_append = " rpi_watchdog"
-RESIN_CONFIGS_DEPS[rpi_watchdog] = " \
+BALENA_CONFIGS_append = " rpi_watchdog"
+BALENA_CONFIGS_DEPS[rpi_watchdog] = " \
     CONFIG_WATCHDOG=y \
 "
-RESIN_CONFIGS[rpi_watchdog] = " \
+BALENA_CONFIGS[rpi_watchdog] = " \
     CONFIG_BCM2835_WDT=y \
 "
 
-RESIN_CONFIGS_append = " kvaser_usb_can_driver"
+BALENA_CONFIGS_append = " kvaser_usb_can_driver"
 
-RESIN_CONFIGS[kvaser_usb_can_driver] = " \
+BALENA_CONFIGS[kvaser_usb_can_driver] = " \
     CONFIG_CAN_KVASER_USB=m \
 "
 
-RESIN_CONFIGS_append = " mcp251x_can_driver"
+BALENA_CONFIGS_append = " mcp251x_can_driver"
 
-RESIN_CONFIGS[mcp251x_can_driver] = " \
+BALENA_CONFIGS[mcp251x_can_driver] = " \
     CONFIG_CAN_MCP251X=m \
 "
 
-RESIN_CONFIGS_DEPS[mcp251x_can_driver] = " \
+BALENA_CONFIGS_DEPS[mcp251x_can_driver] = " \
     CONFIG_SPI=y \
     CONFIG_HAS_DMA=y \
 "
 
-RESIN_CONFIGS_append = " can_calc_bittiming"
+BALENA_CONFIGS_append = " can_calc_bittiming"
 
-RESIN_CONFIGS[can_calc_bittiming] = " \
+BALENA_CONFIGS[can_calc_bittiming] = " \
 		CONFIG_CAN_CALC_BITTIMING=y \
 "
 
-RESIN_CONFIGS_DEPS[can_calc_bittiming] = " \
+BALENA_CONFIGS_DEPS[can_calc_bittiming] = " \
 		CONFIG_CAN_DEV=y \
 "
 
-RESIN_CONFIGS_append = " ds1307_rtc_driver"
+BALENA_CONFIGS_append = " ds1307_rtc_driver"
 
-RESIN_CONFIGS[ds1307_rtc_driver] = " \
+BALENA_CONFIGS[ds1307_rtc_driver] = " \
     CONFIG_RTC_DRV_DS1307=m \
 "
 
-RESIN_CONFIGS_DEPS[ds1307_rtc_driver] = " \
+BALENA_CONFIGS_DEPS[ds1307_rtc_driver] = " \
     CONFIG_I2C=y \
 "
 
-RESIN_CONFIGS_append = " sc16is7xx_serial_driver"
+BALENA_CONFIGS_append = " sc16is7xx_serial_driver"
 
-RESIN_CONFIGS[sc16is7xx_serial_driver] = " \
+BALENA_CONFIGS[sc16is7xx_serial_driver] = " \
     CONFIG_SERIAL_SC16IS7XX=m \
 "
 
-RESIN_CONFIGS_DEPS[sc16is7xx_serial_driver] = " \
+BALENA_CONFIGS_DEPS[sc16is7xx_serial_driver] = " \
     CONFIG_I2C=y \
 "
 
-RESIN_CONFIGS_append = " mcp3422_adc_driver"
+BALENA_CONFIGS_append = " mcp3422_adc_driver"
 
-RESIN_CONFIGS[mcp3422_adc_driver] = " \
+BALENA_CONFIGS[mcp3422_adc_driver] = " \
     CONFIG_MCP3422=m \
 "
 
-RESIN_CONFIGS_DEPS[mcp3422_adc_driver] = " \
+BALENA_CONFIGS_DEPS[mcp3422_adc_driver] = " \
     CONFIG_I2C=y \
 "
 
-RESIN_CONFIGS_append = " sd8787_pwrseq_driver"
+BALENA_CONFIGS_append = " sd8787_pwrseq_driver"
 
-RESIN_CONFIGS[sd8787_pwrseq_driver] = " \
+BALENA_CONFIGS[sd8787_pwrseq_driver] = " \
     CONFIG_PWRSEQ_SD8787=y \
 "
 
-RESIN_CONFIGS_DEPS[sd8787_pwrseq_driver] = " \
+BALENA_CONFIGS_DEPS[sd8787_pwrseq_driver] = " \
     CONFIG_OF=y \
 "
 
-RESIN_CONFIGS_append = " serial_8250"
-RESIN_CONFIGS[serial_8250] = " \
+BALENA_CONFIGS_append = " serial_8250"
+BALENA_CONFIGS[serial_8250] = " \
     CONFIG_SERIAL_8250=y \
     CONFIG_SERIAL_8250_CONSOLE=y \
     CONFIG_SERIAL_8250_NR_UARTS=1 \
@@ -191,8 +191,8 @@ RESIN_CONFIGS[serial_8250] = " \
     CONFIG_SERIAL_8250_BCM2835AUX=y \
 "
 
-RESIN_CONFIGS_append_rt-rpi-300 = " rtrpi300cfgs"
-RESIN_CONFIGS[rtrpi300cfgs] = " \
+BALENA_CONFIGS_append_rt-rpi-300 = " rtrpi300cfgs"
+BALENA_CONFIGS[rtrpi300cfgs] = " \
     CONFIG_RTC_DRV_RX8010=m \
     CONFIG_SPI=y \
     CONFIG_SPI_BCM2835=m \

--- a/layers/meta-balena-raspberrypi/recipes-support/hostapp-update-hooks/files/999-resin-boot-cleaner
+++ b/layers/meta-balena-raspberrypi/recipes-support/hostapp-update-hooks/files/999-resin-boot-cleaner
@@ -11,16 +11,16 @@ set -o errexit
 DURING_UPDATE=${DURING_UPDATE:-0}
 
 if [ "$DURING_UPDATE" = "1" ]; then
-	if  grep -q "ext4load" "$RESIN_BOOT_MOUNTPOINT/boot.scr" ; then
-		if [ -e "$RESIN_BOOT_MOUNTPOINT/zImage" ]; then
+	if  grep -q "ext4load" "$BALENA_BOOT_MOUNTPOINT/boot.scr" ; then
+		if [ -e "$BALENA_BOOT_MOUNTPOINT/zImage" ]; then
 			# Testing the destination sysroot kernel is tricky. Lets check current root
 			# instead as all future roots will have the kernel in root partition in /boot
 			# This leaves the kernel lying around in boot partition until the next HUP
 			if [ -e "/boot/zImage" ]; then
 				printf "[INFO] u-boot boot.scr now reads kernel from root partitions but found zImage in boot \n"
-				printf "[INFO] removing $RESIN_BOOT_MOUNTPOINT/zImage \n"
-				rm -f "$RESIN_BOOT_MOUNTPOINT/zImage" || true
-				sync -f "$RESIN_BOOT_MOUNTPOINT"
+				printf "[INFO] removing $BALENA_BOOT_MOUNTPOINT/zImage \n"
+				rm -f "$BALENA_BOOT_MOUNTPOINT/zImage" || true
+				sync -f "$BALENA_BOOT_MOUNTPOINT"
 			fi
 		fi
 	fi

--- a/nebra-hnt.coffee
+++ b/nebra-hnt.coffee
@@ -27,10 +27,10 @@ module.exports =
 
 	yocto:
 		machine: 'nebra-hnt'
-		image: 'resin-image'
-		fstype: 'resinos-img'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-nebra-hnt.resinos-img'
+		deployArtifact: 'balena-image-nebra-hnt.balenaos-img'
 		compressed: true
 
 	configuration:

--- a/npe-x500-m3.coffee
+++ b/npe-x500-m3.coffee
@@ -28,10 +28,10 @@ module.exports =
 
 	yocto:
 		machine: 'npe-x500-m3'
-		image: 'resin-image'
-		fstype: 'resinos-img'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-npe-x500-m3.resinos-img'
+		deployArtifact: 'balena-image-npe-x500-m3.balenaos-img'
 		compressed: true
 
 	configuration:

--- a/raspberrypi.coffee
+++ b/raspberrypi.coffee
@@ -27,10 +27,10 @@ module.exports =
 
 	yocto:
 		machine: 'raspberrypi'
-		image: 'resin-image'
-		fstype: 'resinos-img'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-raspberrypi.resinos-img'
+		deployArtifact: 'balena-image-raspberrypi.balenaos-img'
 		compressed: true
 
 	configuration:

--- a/raspberrypi2.coffee
+++ b/raspberrypi2.coffee
@@ -27,10 +27,10 @@ module.exports =
 
 	yocto:
 		machine: 'raspberrypi2'
-		image: 'resin-image'
-		fstype: 'resinos-img'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-raspberrypi2.resinos-img'
+		deployArtifact: 'balena-image-raspberrypi2.balenaos-img'
 		compressed: true
 
 	configuration:

--- a/raspberrypi3-64.coffee
+++ b/raspberrypi3-64.coffee
@@ -27,10 +27,10 @@ module.exports =
 
 	yocto:
 		machine: 'raspberrypi3-64'
-		image: 'resin-image'
-		fstype: 'resinos-img'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-raspberrypi3-64.resinos-img'
+		deployArtifact: 'balena-image-raspberrypi3-64.balenaos-img'
 		compressed: true
 
 	configuration:

--- a/raspberrypi3.coffee
+++ b/raspberrypi3.coffee
@@ -28,10 +28,10 @@ module.exports =
 
 	yocto:
 		machine: 'raspberrypi3'
-		image: 'resin-image'
-		fstype: 'resinos-img'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-raspberrypi3.resinos-img'
+		deployArtifact: 'balena-image-raspberrypi3.balenaos-img'
 		compressed: true
 
 	configuration:

--- a/raspberrypi4-64.coffee
+++ b/raspberrypi4-64.coffee
@@ -20,10 +20,10 @@ module.exports =
 
 	yocto:
 		machine: 'raspberrypi4-64'
-		image: 'resin-image'
-		fstype: 'resinos-img'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-raspberrypi4-64.resinos-img'
+		deployArtifact: 'balena-image-raspberrypi4-64.balenaos-img'
 		compressed: true
 
 	configuration:

--- a/raspberrypi400-64.coffee
+++ b/raspberrypi400-64.coffee
@@ -20,10 +20,10 @@ module.exports =
 
 	yocto:
 		machine: 'raspberrypi400-64'
-		image: 'resin-image'
-		fstype: 'resinos-img'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-raspberrypi400-64.resinos-img'
+		deployArtifact: 'balena-image-raspberrypi400-64.balenaos-img'
 		compressed: true
 
 	configuration:

--- a/raspberrypicm4-ioboard.coffee
+++ b/raspberrypicm4-ioboard.coffee
@@ -30,10 +30,10 @@ module.exports =
 
 	yocto:
 		machine: 'raspberrypicm4-ioboard'
-		image: 'resin-image'
-		fstype: 'resinos-img'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-raspberrypicm4-ioboard.resinos-img'
+		deployArtifact: 'balena-image-raspberrypicm4-ioboard.balenaos-img'
 		compressed: true
 
 	configuration:

--- a/revpi-connect.coffee
+++ b/revpi-connect.coffee
@@ -32,10 +32,10 @@ module.exports =
 
 	yocto:
 		machine: 'revpi-connect'
-		image: 'resin-image'
-		fstype: 'resinos-img'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-revpi-connect.resinos-img'
+		deployArtifact: 'balena-image-revpi-connect.balenaos-img'
 		compressed: true
 
 	configuration:

--- a/revpi-core-3.coffee
+++ b/revpi-core-3.coffee
@@ -33,10 +33,10 @@ module.exports =
 
 	yocto:
 		machine: 'revpi-core-3'
-		image: 'resin-image'
-		fstype: 'resinos-img'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-revpi-core-3.resinos-img'
+		deployArtifact: 'balena-image-revpi-core-3.balenaos-img'
 		compressed: true
 
 	configuration:

--- a/rt-rpi-300.coffee
+++ b/rt-rpi-300.coffee
@@ -19,10 +19,10 @@ module.exports =
 
 	yocto:
 		machine: 'rt-rpi-300'
-		image: 'resin-image'
-		fstype: 'resinos-img'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-rt-rpi-300.resinos-img'
+		deployArtifact: 'balena-image-rt-rpi-300.balenaos-img'
 		compressed: true
 
 	configuration:


### PR DESCRIPTION
Rename resin image types to balena and replace RESIN_ env vars

Changelog-entry: Rename resin image types to balena
Signed-off-by: Kyle Harding <kyle@balena.io>