### PR TITLE
conf/samples: Switch HNT device to overlay2

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
+++ b/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
@@ -15,6 +15,7 @@ BALENA_STORAGE_rt-rpi-300 = "overlay2"
 BALENA_STORAGE_raspberrypi4-64 = "overlay2"
 BALENA_STORAGE_raspberrypi400-64 = "overlay2"
 BALENA_STORAGE_revpi-connect = "overlay2"
+BALENA_STORAGE_nebra-hnt = "overlay2"
 
 # More info meta-resin/README.md
 #TARGET_REPOSITORY ?= ""


### PR DESCRIPTION
We do so because all new added devices
should use overlay2 by default.

Changelog-entry: conf/samples: Switch HNT device to overlay2
Signed-off-by: Alexandru Costache <alexandru@balena.io>