### PR TITLE
bluez5: Add pending upstream patches for Nebra HNT

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/machine/nebra-hnt.conf
+++ b/layers/meta-balena-raspberrypi/conf/machine/nebra-hnt.conf
@@ -8,3 +8,7 @@ include conf/machine/raspberrypi3-64.conf
 # because we override the raspberrypi3-64 machine which in turn is an override of raspberrypi3, we need to do the following gimmick:
 # courtesy of https://github.com/balena-os/balena-jetson/pull/112/commits/9d21df6899e595b4aeab4cc9a939ae6c564c669a
 MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':raspberrypi3-64:${MACHINE}')}"
+
+# Use this version until it's updated in poky,
+# to test the pending upstream patches
+PREFERRED_VERSION_bluez5 = "5.56"

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/rpi4-disable-pl01-serial-driver.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/rpi4-disable-pl01-serial-driver.patch
@@ -1,6 +1,6 @@
-From 53f5425ec5979df0b2db210505c3dea84e6fb2c8 Mon Sep 17 00:00:00 2001
+From 1a83a67acc39bb7343df41f9095c0e79c9c9a148 Mon Sep 17 00:00:00 2001
 From: Alexandru Costache <alexandru@balena.io>
-Date: Thu, 27 Aug 2020 14:27:46 +0200
+Date: Mon, 8 Mar 2021 16:14:40 +0100
 Subject: [PATCH] pl01: Disable driver in production builds
 
 Do so when enable_uart is not set in config.txt,
@@ -15,17 +15,17 @@ Signed-off-by: Alexandru Costache <alexandru@balena.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/serial/serial_pl01x.c b/drivers/serial/serial_pl01x.c
-index 6e5d81ce34..199bef2f4f 100644
+index b9b7fbbe23..1df42fc68f 100644
 --- a/drivers/serial/serial_pl01x.c
 +++ b/drivers/serial/serial_pl01x.c
-@@ -375,7 +375,7 @@ int pl01x_serial_ofdata_to_platdata(struct udevice *dev)
+@@ -394,7 +394,7 @@ int pl01x_serial_of_to_plat(struct udevice *dev)
  U_BOOT_DRIVER(serial_pl01x) = {
  	.name	= "serial_pl01x",
  	.id	= UCLASS_SERIAL,
 -	.of_match = of_match_ptr(pl01x_serial_id),
 +	.of_match = NULL,
- 	.ofdata_to_platdata = of_match_ptr(pl01x_serial_ofdata_to_platdata),
- 	.platdata_auto_alloc_size = sizeof(struct pl01x_serial_platdata),
+ 	.of_to_plat = of_match_ptr(pl01x_serial_of_to_plat),
+ 	.plat_auto	= sizeof(struct pl01x_serial_plat),
  	.probe = pl01x_serial_probe,
 -- 
 2.17.1

--- a/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/0001-Allow-using-obexd-without-systemd-in-the-user-sessio.patch
+++ b/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/0001-Allow-using-obexd-without-systemd-in-the-user-sessio.patch
@@ -1,0 +1,56 @@
+From f74eb97c9fb3c0ee2895742e773ac6a3c41c999c Mon Sep 17 00:00:00 2001
+From: Giovanni Campagna <gcampagna-cNUdlRotFMnNLxjTenLetw@public.gmane.org>
+Date: Sat, 12 Oct 2013 17:45:25 +0200
+Subject: [PATCH] Allow using obexd without systemd in the user session
+
+Not all sessions run systemd --user (actually, the majority
+doesn't), so the dbus daemon must be able to spawn obexd
+directly, and to do so it needs the full path of the daemon.
+
+Upstream-Status: Denied
+
+Not accepted by upstream maintainer for being a distro specific
+configuration. See thread:
+
+http://thread.gmane.org/gmane.linux.bluez.kernel/38725/focus=38843
+
+Signed-off-by: Javier Viguera <javier.viguera@digi.com>
+
+---
+ Makefile.obexd                                                | 4 ++--
+ .../src/{org.bluez.obex.service => org.bluez.obex.service.in} | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+ rename obexd/src/{org.bluez.obex.service => org.bluez.obex.service.in} (76%)
+
+diff --git a/Makefile.obexd b/Makefile.obexd
+index de59d29..73004a3 100644
+--- a/Makefile.obexd
++++ b/Makefile.obexd
+@@ -1,12 +1,12 @@
+ if SYSTEMD
+ systemduserunitdir = $(SYSTEMD_USERUNITDIR)
+ systemduserunit_DATA = obexd/src/obex.service
++endif
+ 
+ dbussessionbusdir = $(DBUS_SESSIONBUSDIR)
+ dbussessionbus_DATA = obexd/src/org.bluez.obex.service
+-endif
+ 
+-EXTRA_DIST += obexd/src/obex.service.in obexd/src/org.bluez.obex.service
++EXTRA_DIST += obexd/src/obex.service.in obexd/src/org.bluez.obex.service.in
+ 
+ if OBEX
+ 
+diff --git a/obexd/src/org.bluez.obex.service b/obexd/src/org.bluez.obex.service.in
+similarity index 76%
+rename from obexd/src/org.bluez.obex.service
+rename to obexd/src/org.bluez.obex.service.in
+index a538088..9c815f2 100644
+--- a/obexd/src/org.bluez.obex.service
++++ b/obexd/src/org.bluez.obex.service.in
+@@ -1,4 +1,4 @@
+ [D-BUS Service]
+ Name=org.bluez.obex
+-Exec=/bin/false
++Exec=@libexecdir@/obexd
+ SystemdService=dbus-org.bluez.obex.service

--- a/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/0001-test-gatt-Fix-hung-issue.patch
+++ b/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/0001-test-gatt-Fix-hung-issue.patch
@@ -1,0 +1,43 @@
+From 61e741654cc2eb167bca212a3bb2ba8f3ba280c1 Mon Sep 17 00:00:00 2001
+From: Mingli Yu <Mingli.Yu@windriver.com>
+Date: Fri, 24 Aug 2018 12:04:03 +0800
+Subject: [PATCH] test-gatt: Fix hung issue
+
+The below test hangs infinitely
+$ unit/test-gatt -p  /robustness/unkown-request -d
+/robustness/unkown-request - init
+/robustness/unkown-request - setup
+/robustness/unkown-request - setup complete
+/robustness/unkown-request - run
+  GATT: < 02 17 00                                         ...
+  bt_gatt_server:MTU exchange complete, with MTU: 23
+  GATT: > 03 00 02                                         ...
+  PDU: = 03 00 02                                         ...
+  GATT: < bf 00
+
+Actually, the /robustness/unkown-request test does
+no action.
+
+Upstream-Status: Submitted [https://marc.info/?l=linux-bluetooth&m=153508881804635&w=2]
+
+Signed-off-by: Mingli Yu <Mingli.Yu@windriver.com>
+---
+ unit/test-gatt.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/unit/test-gatt.c b/unit/test-gatt.c
+index c7e28f8..b57373b 100644
+--- a/unit/test-gatt.c
++++ b/unit/test-gatt.c
+@@ -4463,7 +4463,7 @@ int main(int argc, char *argv[])
+ 			test_server, service_db_1, NULL,
+ 			raw_pdu(0x03, 0x00, 0x02),
+ 			raw_pdu(0xbf, 0x00),
+-			raw_pdu(0x01, 0xbf, 0x00, 0x00, 0x06));
++			raw_pdu());
+ 
+ 	define_test_server("/robustness/unkown-command",
+ 			test_server, service_db_1, NULL,
+-- 
+2.7.4
+

--- a/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/0001-tests-add-a-target-for-building-tests-without-runnin.patch
+++ b/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/0001-tests-add-a-target-for-building-tests-without-runnin.patch
@@ -1,0 +1,28 @@
+From 4bdf0f96dcaa945fd29f26d56e5b36d8c23e4c8b Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Fri, 1 Apr 2016 17:07:34 +0300
+Subject: [PATCH] tests: add a target for building tests without running them
+
+Upstream-Status: Inappropriate [oe specific]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ Makefile.am | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Makefile.am b/Makefile.am
+index 1a48a71..ba3b92f 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -425,6 +425,9 @@ endif
+ TESTS = $(unit_tests)
+ AM_TESTS_ENVIRONMENT = MALLOC_CHECK_=3 MALLOC_PERTURB_=69
+ 
++# This allows building tests without running them
++buildtests: $(TESTS)
++
+ if DBUS_RUN_SESSION
+ AM_TESTS_ENVIRONMENT += dbus-run-session --
+ endif
+-- 
+2.8.0.rc3
+

--- a/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/fix-registerin-dis-without-valid-source.patch
+++ b/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/fix-registerin-dis-without-valid-source.patch
@@ -1,0 +1,64 @@
+From df2e9780141660ea48a3298c9e53aaa88590daa0 Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Mon, 8 Mar 2021 09:59:00 +0200
+Subject: [PATCH] From 00bd886066f005fc6447c280df7fbac07a16bddc Mon Sep 17
+ 00:00:00 2001 From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com> Date:
+ Fri, 5 Mar 2021 14:25:44 -0800 Subject: [PATCH] gatt: Fix registering DIS
+ without a valid source
+
+If source has not been set don't register DIS as it would not contain
+any useful information and by doing this it actually allows systems to
+register their own DIS instance.
+
+Fixes https://github.com/bluez/bluez/issues/101
+
+Author: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
+
+NOTE: Should be removed when merged in upstream master
+and Bluez is updated to 5.56+ in poky.
+
+Upstream-status: Pending
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ src/gatt-database.c | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/src/gatt-database.c b/src/gatt-database.c
+index bd5864bcd..6c9e19ff3 100644
+--- a/src/gatt-database.c
++++ b/src/gatt-database.c
+@@ -1241,22 +1241,23 @@ static void device_info_read_pnp_id_cb(struct gatt_db_attribute *attrib,
+ static void populate_devinfo_service(struct btd_gatt_database *database)
+ {
+ 	struct gatt_db_attribute *service;
++	struct gatt_db_attribute *attrib;
+ 	bt_uuid_t uuid;
+ 
++	/* Only register DIS if source has been set */
++	if (!btd_opts.did_source)
++		return;
++
+ 	bt_uuid16_create(&uuid, UUID_DIS);
+ 	service = gatt_db_add_service(database->db, &uuid, true, 3);
+ 
+-	if (btd_opts.did_source > 0) {
+-		struct gatt_db_attribute *attrib;
+-
+-		bt_uuid16_create(&uuid, GATT_CHARAC_PNP_ID);
+-		attrib = gatt_db_service_add_characteristic(service, &uuid,
++	bt_uuid16_create(&uuid, GATT_CHARAC_PNP_ID);
++	attrib = gatt_db_service_add_characteristic(service, &uuid,
+ 						BT_ATT_PERM_READ,
+ 						BT_GATT_CHRC_PROP_READ,
+ 						device_info_read_pnp_id_cb,
+ 						NULL, database);
+-		gatt_db_attribute_set_fixed_length(attrib, 7);
+-	}
++	gatt_db_attribute_set_fixed_length(attrib, 7);
+ 
+ 	gatt_db_service_set_active(service, true);
+ 
+ 
+-- 
+2.17.1
+

--- a/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/init
+++ b/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/init
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+# Source function library
+. /etc/init.d/functions
+
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+DESC=bluetooth
+
+DAEMON=@LIBEXECDIR@/bluetooth/bluetoothd
+
+# If you want to be ignore error of "org.freedesktop.hostname1",
+# please enable NOPLUGIN_OPTION.
+# NOPLUGIN_OPTION="--noplugin=hostname"
+NOPLUGIN_OPTION=""
+SSD_OPTIONS="--oknodo --quiet --exec $DAEMON -- $NOPLUGIN_OPTION"
+
+test -f $DAEMON || exit 0
+
+# FIXME: any of the sourced files may fail if/with syntax errors
+test -f /etc/default/bluetooth && . /etc/default/bluetooth
+test -f /etc/default/rcS && . /etc/default/rcS
+
+set -e
+
+case $1 in
+  start)
+	echo -n "Starting $DESC: "
+	if test "$BLUETOOTH_ENABLED" = 0; then
+		echo "disabled (see /etc/default/bluetooth)."
+		exit 0
+	fi
+	start-stop-daemon --start --background $SSD_OPTIONS
+	echo "${DAEMON##*/}."
+  ;;
+  stop)
+	echo -n "Stopping $DESC: "
+	if test "$BLUETOOTH_ENABLED" = 0; then
+		echo "disabled (see /etc/default/bluetooth)."
+		exit 0
+	fi
+	start-stop-daemon --stop $SSD_OPTIONS
+	echo "${DAEMON##*/}."
+  ;;
+  restart|force-reload)
+	$0 stop
+	sleep 1
+	$0 start
+  ;;
+  status)
+	status ${DAEMON} || exit $?
+   ;;
+   *)
+	N=/etc/init.d/bluetooth
+	echo "Usage: $N {start|stop|restart|force-reload|status}" >&2
+	exit 1
+	;;
+esac
+
+exit 0
+
+# vim:noet

--- a/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/main-conf-enable-passing-false-deviceid.patch
+++ b/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/main-conf-enable-passing-false-deviceid.patch
@@ -1,0 +1,55 @@
+From d08e54b68ca375e361e5cd5bd0e82ed3cd6033e3 Mon Sep 17 00:00:00 2001
+From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
+Date: Fri, 5 Mar 2021 15:00:03 -0800
+Subject: [PATCH] main.conf: Enable passing false to DeviceID
+
+This adds support for setting DeviceID to false so plaforms can disable
+DeviceID.
+
+Fixes: https://github.com/bluez/bluez/issues/101
+
+Author: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
+
+Upstream-status: Backport
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ src/main.c    | 8 +++++++-
+ src/main.conf | 2 +-
+ 2 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/main.c b/src/main.c
+index b66e2b8cb..572dc939c 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -188,10 +188,16 @@ static void parse_did(const char *did)
+ 	int result;
+ 	uint16_t vendor, product, version , source;
+ 
+-	/* version and source are optional */
++	vendor = 0x0000;
++	product = 0x0000;
+ 	version = 0x0000;
+ 	source = 0x0002;
+ 
++	if (!strcasecmp(did, "false")) {
++		source = 0x0000;
++		goto done;
++	}
++
+ 	result = sscanf(did, "bluetooth:%4hx:%4hx:%4hx",
+ 					&vendor, &product, &version);
+ 	if (result != EOF && result >= 2) {
+diff --git a/src/main.conf b/src/main.conf
+index ad36638b7..f47cab46d 100644
+--- a/src/main.conf
++++ b/src/main.conf
+@@ -26,7 +26,7 @@
+ # Use vendor id source (assigner), vendor, product and version information for
+ # DID profile support. The values are separated by ":" and assigner, VID, PID
+ # and version.
+-# Possible vendor id source values: bluetooth, usb (defaults to usb)
++# Possible vendor id source values: bluetooth, usb (default) or false (disabled)
+ #DeviceID = bluetooth:1234:5678:abcd
+ 
+ # Do reverse service discovery for previously unknown devices that connect to
+

--- a/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/run-ptest
+++ b/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/run-ptest
@@ -1,0 +1,31 @@
+#! /bin/sh
+
+cd unit
+
+failed=0
+all=0
+
+for f in test-*; do
+    "./$f" -q
+    case "$?" in
+        0)
+            echo "PASS: $f"
+            all=$((all + 1))
+            ;;
+        77)
+            echo "SKIP: $f"
+            ;;
+        *)
+            echo "FAIL: $f"
+            failed=$((failed + 1))
+            all=$((all + 1))
+            ;;
+    esac
+done
+
+if [ "$failed" -eq 0 ] ; then
+  echo "All $all tests passed"
+else
+  echo "$failed of $all tests failed"
+fi
+

--- a/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,6 +1,16 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
 SRC_URI_remove_fincm3 = "file://0001-bcm43xx-Add-bcm43xx-3wire-variant.patch"
 SRC_URI_remove_fincm3 = "file://0002-bcm43xx-The-UART-speed-must-be-reset-after-the-firmw.patch"
 SRC_URI_remove_fincm3 = "file://0003-Increase-firmware-load-timeout-to-30s.patch"
 SRC_URI_remove_fincm3 = "file://0004-Move-the-43xx-firmware-into-lib-firmware.patch"
 
 RDEPENDS_${PN}_remove_fincm3 = "pi-bluetooth"
+
+# These patches are specific to this device's
+# use-case and should be removed once
+# an updated Bluez version from Poky includes them.
+SRC_URI_append_nebra-hnt = " \
+    file://fix-registerin-dis-without-valid-source.patch \
+    file://main-conf-enable-passing-false-deviceid.patch \
+"

--- a/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5_5.56.bb
+++ b/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5_5.56.bb
@@ -1,0 +1,72 @@
+require recipes-connectivity/bluez5/bluez5.inc
+SRC_URI[md5sum] = "e6c51b2aefa7c56ff072819a78611fa5"
+SRC_URI[sha256sum] = "59c4dba9fc8aae2a6a5f8f12f19bc1b0c2dc27355c7ca3123eed3fe6bd7d0b9d"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e \
+                    file://COPYING.LIB;md5=fb504b67c50331fc78734fed90fb0e09 \
+                    file://src/main.c;beginline=1;endline=24;md5=0ad83ca0dc37ab08af448777c581e7ac"
+# noinst programs in Makefile.tools that are conditional on READLINE
+# support
+NOINST_TOOLS_READLINE ?= " \
+    ${@bb.utils.contains('PACKAGECONFIG', 'deprecated', 'attrib/gatttool', '', d)} \
+    tools/obex-client-tool \
+    tools/obex-server-tool \
+    tools/bluetooth-player \
+    tools/obexctl \
+    tools/btmgmt \
+"
+
+# noinst programs in Makefile.tools that are conditional on TESTING
+# support
+NOINST_TOOLS_TESTING ?= " \
+    emulator/btvirt \
+    emulator/b1ee \
+    emulator/hfp \
+    peripheral/btsensor \
+    tools/3dsp \
+    tools/mgmt-tester \
+    tools/gap-tester \
+    tools/l2cap-tester \
+    tools/sco-tester \
+    tools/smp-tester \
+    tools/hci-tester \
+    tools/rfcomm-tester \
+    tools/bnep-tester \
+    tools/userchan-tester \
+"
+
+# noinst programs in Makefile.tools that are conditional on TOOLS
+# support
+NOINST_TOOLS_BT ?= " \
+    tools/bdaddr \
+    tools/avinfo \
+    tools/avtest \
+    tools/scotest \
+    tools/amptest \
+    tools/hwdb \
+    tools/hcieventmask \
+    tools/hcisecfilter \
+    tools/btinfo \
+    tools/btsnoop \
+    tools/btproxy \
+    tools/btiotest \
+    tools/bneptest \
+    tools/mcaptest \
+    tools/cltest \
+    tools/oobtest \
+    tools/advtest \
+    tools/seq2bseq \
+    tools/nokfw \
+    tools/create-image \
+    tools/eddystone \
+    tools/ibeacon \
+    tools/btgatt-client \
+    tools/btgatt-server \
+    tools/test-runner \
+    tools/check-selftest \
+    tools/gatt-service \
+    profiles/iap/iapd \
+    ${@bb.utils.contains('PACKAGECONFIG', 'btpclient', 'tools/btpclient', '', d)} \
+"
+
+COMPATIBLE_MACHINE="nebra-hnt"


### PR DESCRIPTION
The 000x patches, init and run-ptest come from poky
bluez 5.55, the other two are backported from github
bluez issue 101. We update to Bluez 5.56 to apply these
two pending patches and check if they solve an issue
that affects this board's use-case.