### PR TITLE
u-boot: include previous version for pl01 patch

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -61,6 +61,6 @@ SRC_URI_append_raspberrypi4-64 = " \
 # the pi4 serial driver freeze. Let's not use this driver in
 # production, because we don't want to output anything to the
 # console anyway.
-SRC_URI_append = " \
+SRC_URI_append_raspberrypi4-64 = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'development-image', '', 'file://rpi4-disable-pl01-serial-driver.patch', d)} \
 "


### PR DESCRIPTION
We include this change for all the rpi boards, Pi4
uses an updated u-boot for pi400 and cm4 support
so it needs a slightly rebased version of the patch.

Change-type: Patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>