### PR TITLE
Disable GATT 180A service provided by BlueZ For Nebra HNT

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/main.conf
+++ b/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5/nebra-hnt/main.conf
@@ -1,0 +1,7 @@
+[General]
+
+# Use vendor id source (assigner), vendor, product and version information for
+# DID profile support. The values are separated by ":" and assigner, VID, PID
+# and version.
+# Possible vendor id source values: bluetooth, usb (defaults to usb), false
+DeviceID = false

--- a/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -13,4 +13,10 @@ RDEPENDS_${PN}_remove_fincm3 = "pi-bluetooth"
 SRC_URI_append_nebra-hnt = " \
     file://fix-registerin-dis-without-valid-source.patch \
     file://main-conf-enable-passing-false-deviceid.patch \
+    file://main.conf \
 "
+
+do_install_append_nebra-hnt() {
+    install -d ${D}${sysconfdir}/bluetooth
+    install -m 644  ${WORKDIR}/main.conf ${D}/etc/bluetooth
+}


### PR DESCRIPTION
Related to issue https://github.com/balena-os/balena-raspberrypi/issues/620

While the PR that upgrades to BlueZ 5.56 is now added along with the patch to allow the feature that's causing us issues is now integrated. To actually disable the feature requires a value set as false in the main.conf.

As no main.conf is provided in Balena OS I believe this PR should add a main.conf to the `/etc/bluetooth/` directory with the contents required.

I've tested this on a unit by adding the file to the Host OS  manually and it seems to resolve the issue. 

I believe I've done the patch correctly but I'm not an expert in Yocto so a double check would be great.

Thanks