### PR TITLE
raspberrypi3-unipi-neuron.coffee: Fix typo

### DIFF
--- a/raspberrypi3-unipi-neuron.coffee
+++ b/raspberrypi3-unipi-neuron.coffee
@@ -25,11 +25,11 @@ module.exports =
 	options: [ networkOptions.group ]
 
 	yocto:
-		machine: 'raspberry3-unipi-neuron'
+		machine: 'raspberrypi3-unipi-neuron'
 		image: 'balena-image'
 		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'balena-image-raspberry3-unipi-neuron.balenaos-img'
+		deployArtifact: 'balena-image-raspberrypi3-unipi-neuron.balenaos-img'
 		compressed: true
 
 	configuration:


### PR DESCRIPTION
Changelog-entry: Fix typo in raspberrypi3-unipi-neuron.coffee file
Signed-off-by: Florin Sarbu <florin@balena.io>