### PR TITLE
kernel: Enable overlayfs support

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -1,0 +1,3 @@
+
+# install overlay2 support even when BALENA_STORAGE is aufs
+BALENA_CONFIGS_append = " overlay2"


### PR DESCRIPTION
This is needed in preparation of the storage mirgation.
When running hostapp-update, we need to create the target hostapp on
overlayfs, which implies the OS we update from can support both drivers.

Change-type: minor
Signed-off-by: Robert Günzler <robertg@balena.io>

---

```
root@balena:~# cat /proc/filesystems | grep aufs
nodev   aufs
root@balena:~# cat /proc/filesystems | grep overlay
nodev   overlay
```