### PR TITLE
unipi-tools: Fix binaries install

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-extended/unipi-tools/unipi-tools.bb
+++ b/layers/meta-balena-raspberrypi/recipes-extended/unipi-tools/unipi-tools.bb
@@ -7,6 +7,7 @@ SRC_URI = "git://git@git.unipi.technology/UniPi/unipi-tools.git;protocol=https"
 inherit systemd
 
 DEPENDS += "libmodbus systemd"
+RDEPENDS_${PN} += "libmodbus"
 
 SRCREV = "1.2.44"
 
@@ -34,7 +35,7 @@ do_install() {
 
     # install the tools
     install -d ${D}/opt/unipi/tools
-    install -m 0644 \
+    install -m 0755 \
     ${S}/unipi_tcp_server \
     ${S}/fwspi \
     ${S}/fwserial \


### PR DESCRIPTION
The binaries were missing execution bit set and also we were missing the
libmodbus dependency in the rootfs.

Changelog-entry: Fix unipi-tools binaries installation
Signed-off-by: Florin Sarbu <florin@balena.io>