### PR TITLE
meta-balena-raspberrypi:layer.conf: Add mcp251xfd overlay to rootfs

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -114,6 +114,7 @@ KERNEL_DEVICETREE_append = " \
     overlays/mcp23s17.dtbo \
     overlays/mcp2515-can0.dtbo \
     overlays/mcp2515-can1.dtbo \
+    overlays/mcp251xfd.dtbo \
     overlays/mcp3008.dtbo \
     overlays/mcp3202.dtbo \
     overlays/mcp342x.dtbo \


### PR DESCRIPTION
Include the mcp251xfd overlay to rootfs as per popular demand

Changelog-entry: Add mcp251xfd overlay to rootfs
Signed-off-by: Florin Sarbu <florin@balena.io>