### PR TITLE
layers/meta-balena: Update to v2.77.0

### DIFF
--- a/revpi-connect.coffee
+++ b/revpi-connect.coffee
@@ -12,7 +12,6 @@ module.exports =
 	name: 'Revolution Pi Connect'
 	arch: 'armv7hf'
 	state: 'new'
-	community: true
 
 	instructions: [
 		REVPI_DEBUG


### PR DESCRIPTION
Update meta-balena from 2.75.0 to 2.77.0

Changelog-entry: Update meta-balena from v2.75.0 to v2.77.0
Signed-off-by: Florin Sarbu <florin@balena.io>