### PR TITLE
meta-balena-raspberrypi:layer.conf: Add rpi-400,rpi-cm4 dtbs for rpi4-64

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -317,3 +317,6 @@ UBOOT_MACHINE_raspberrypi4-64 = "rpi_arm64_defconfig"
 # and the mouse support in the kernel.
 
 RPI_KERNEL_DEVICETREE_append_raspberrypi3-64 = " broadcom/bcm2710-rpi-cm3.dtb"
+
+RPI_KERNEL_DEVICETREE_append_raspberrypi4-64 = " broadcom/bcm2711-rpi-400.dtb"
+RPI_KERNEL_DEVICETREE_append_raspberrypi4-64 = " broadcom/bcm2711-rpi-cm4.dtb"


### PR DESCRIPTION
Because the BSP in the dunfell branch does not currently ship these dtbs
in the raspberrypi4-64 machine let's just add it from here instead.

Changelog-entry: Add bcm2711-rpi-400.dtb and bcm2711-rpi-cm4.dtb for the raspberrypi4-64 machine
Signed-off-by: Florin Sarbu <florin@balena.io>