### PR TITLE
Bump 5.10 kernel version and bootfiles

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -15,7 +15,6 @@ LAYERSERIES_COMPAT_balena-raspberrypi = "dunfell"
 # the ones already defined in meta-raspberrypi/conf/machine/include/rpi-base.inc.
 # They have been renamed to match rpi-base.inc.
 KERNEL_DEVICETREE_append = " \
-    overlays/2xmcp2517fd.dtbo \
     overlays/act-led.dtbo \
     overlays/adafruit18.dtbo \
     overlays/adau1977-adc.dtbo \
@@ -135,6 +134,7 @@ KERNEL_DEVICETREE_append = " \
     overlays/overlay_map.dtb \
     overlays/papirus.dtbo \
     overlays/pca953x.dtbo \
+    overlays/pcie-32bit-dma.dtbo \
     overlays/pibell.dtbo \
     overlays/pifacedigital.dtbo \
     overlays/piglow.dtbo \

--- a/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/bootfiles.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/bootfiles.bbappend
@@ -1,10 +1,10 @@
 FILESEXTRAPATHS_append := ":${THISDIR}/files"
 
-RPIFW_DATE = "20210205"
-SRCREV = "7d91570f20378afc9414107dccdad70705a8a342"
+RPIFW_DATE = "20210421"
+SRCREV = "2ac4de4eaac5c1d1b25acec4a5e0a9fdb16f0c91"
 
-SRC_URI[md5sum] = "e5e9859f845918ad6d8e3bfc06fe0c2f"
-SRC_URI[sha256sum] = "2cc9bf2cbcab8283db2eb53ed2a49372b70fe76538994c32f6d261e2da3e9ff4"
+SRC_URI[md5sum] = "43c92418c2634d4c0c8ce3da696dcad5"
+SRC_URI[sha256sum] = "c687aa1b5127a8dc0773e8aefb1f009f24bf71ccb4c9e8b40a1d46cbbb7bee0c"
 
 LIC_FILES_CHKSUM = "file://LICENCE.broadcom;md5=c403841ff2837657b2ed8e5bb474ac8d"
 

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.10.bb
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.10.bb
@@ -1,11 +1,11 @@
 # copied from meta-raspberrypi@ef04a3a523e6cd935968f34f338501fd915c506c
 # and renamed linux-raspberrypi.inc to linux-raspberrypi_5.10.inc
 
-LINUX_VERSION ?= "5.10.17"
+LINUX_VERSION ?= "5.10.31"
 LINUX_RPI_BRANCH ?= "rpi-5.10.y"
 
-SRCREV_machine = "ec967eb45f8d4ed59bebafb5748da38118383be7"
-SRCREV_meta = "5833ca701711d487c9094bd1efc671e8ef7d001e"
+SRCREV_machine = "89399e6e7e33d6260a954603ca03857df594ffd3"
+SRCREV_meta = "a19886b00ea7d874fdd60d8e3435894bb16e6434"
 
 KMETA = "kernel-meta"
 


### PR DESCRIPTION
Also needed to remove an overlay that wouldn't compile.  I added the pcie-32bit-dma.dtbo overlay that is needed to support some pcie devices (like the ASM1142).