### PR TITLE
rtl8812au: Add recipe for this driver

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -58,6 +58,10 @@ REMOVED_FOR_HUP_SPACE = " \
     linux-firmware-mt7601u \
 "
 
+CONNECTIVITY_MODULES =+ " \
+        rtl8812au \
+"
+
 # Temporary make space for HUP, untill firmwares
 # are provided by hostapp-extensions
 CONNECTIVITY_FIRMWARES_remove_raspberrypi400-64 = "${REMOVED_FOR_HUP_SPACE}"

--- a/layers/meta-balena-raspberrypi/recipes-kernel/rtl8812au/files/0001-Use-modules_install-as-wanted-by-yocto.patch
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/rtl8812au/files/0001-Use-modules_install-as-wanted-by-yocto.patch
@@ -1,0 +1,28 @@
+From 30836d3579b3536ce174082f451acf7fea638a8d Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei@resin.io>
+Date: Mon, 1 Aug 2016 23:51:45 +0200
+Subject: [PATCH] Use modules_install as wanted by yocto
+
+Upstream-Status: Pending
+
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+---
+ Makefile | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 70c609a..b5ecf55 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1051,6 +1051,9 @@ all: modules
+ modules:
+ 	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd)  modules
+ 
++modules_install:
++	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd)  modules_install
++
+ strip:
+ 	$(CROSS_COMPILE)strip $(MODULE_NAME).ko --strip-unneeded
+ 
+-- 
+2.1.4

--- a/layers/meta-balena-raspberrypi/recipes-kernel/rtl8812au/rtl8812au_5.2.20.2.bb
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/rtl8812au/rtl8812au_5.2.20.2.bb
@@ -1,0 +1,22 @@
+SUMMARY = "Realtek 802.11n WLAN Adapter Linux driver"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://Kconfig;md5=4b85004ff83dd932ff28f7f348fb2a28"
+
+inherit module
+
+SRC_URI = " \
+	git://github.com/gordboy/rtl8812au.git;protocol=https \
+	file://0001-Use-modules_install-as-wanted-by-yocto.patch \
+"
+
+# Latest HEAD as of today
+# We leave this here so we know which OS release
+# contains which version of the driver. Using autorev
+# makes it difficult to determine which version a build
+# uses - may cause a staging build use one version and the
+# prod use another
+SRCREV = "772ad434b91a8cc1a0f5a0bd227d46a5caf610ec"
+
+S = "${WORKDIR}/git"
+
+EXTRA_OEMAKE_append = " KSRC=${STAGING_KERNEL_DIR}"


### PR DESCRIPTION
This should not be merged until host extensions are available because there is not enough space in the rootfs to include the module.