### PR TITLE
linux-raspberrypi: Add gasket driver for raspberrypi4-64

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.10.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.10.bbappend
@@ -185,3 +185,9 @@ BALENA_CONFIGS[rtrpi300cfgs] = " \
     CONFIG_SPI_BCM2835=m \
     CONFIG_CH432T_SPI=m \
 "
+
+BALENA_CONFIGS_append_raspberrypi4-64 = " gasket"
+BALENA_CONFIGS[gasket] = " \
+        CONFIG_STAGING_GASKET_FRAMEWORK=m \
+        CONFIG_STAGING_APEX_DRIVER=m \
+"


### PR DESCRIPTION
Changelog-entry: linux-raspberrypi: Add gasket driver for raspberrypi4-64
Signed-off-by: Kyle Harding <kyle@balena.io>