### PR TITLE
Restore linux-firmware-ralink firmware for cm4-ioboard and pi400

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -47,7 +47,6 @@ REMOVED_FOR_HUP_SPACE = " \
     linux-firmware-rtl8723b-bt \
     linux-firmware-ralink-nic \
     linux-firmware-ath9k \
-    linux-firmware-ralink \
     linux-firmware-rtl8192cu \
     linux-firmware-rtl8192su \
     linux-firmware-bcm43143 \


### PR DESCRIPTION
Hello! I had requested a previous change to enable support for a specific USB Wifi adapter for the Raspberry PI CM4. See https://github.com/balena-os/balena-raspberrypi/pull/705)

[However, the adapter I had requested does not support Access point mode (contrary to documentation)](https://github.com/balena-os/wifi-connect/issues/413), meaning that the Wifi-Connect service cannot be used with it.

I am submitting this change to allow use of the [Panda Wireless Adapters](https://www.amazon.com/dp/B00762YNMG?psc=1&ref=ppx_yo2_dt_b_product_details) which are well supported by Network Manager and will allow use of Wifi Connect. 

These adapters use the rt2870.bin file provided by linux-firmware-ralink.

I believe this change is the only one that is required. Let me know what else needs to happen!