### PR TITLE
meta-balena-raspberrypi:layer.conf: Add PoE+ overlay to rootfs

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -150,6 +150,7 @@ KERNEL_DEVICETREE_append = " \
     overlays/rpi-cirrus-wm5102.dtbo \
     overlays/rpi-dac.dtbo \
     overlays/rpi-display.dtbo \
+    overlays/rpi-poe-plus.dtbo \
     overlays/rpi-proto.dtbo \
     overlays/rpi-sense.dtbo \
     overlays/rpi-tv.dtbo \
@@ -302,6 +303,7 @@ KERNEL_DEVICETREE_remove_revpi = "overlays/hifiberry-dacplushd.dtbo"
 KERNEL_DEVICETREE_remove_revpi = "overlays/merus-amp.dtbo"
 KERNEL_DEVICETREE_remove_revpi = "overlays/overlay_map.dtb"
 KERNEL_DEVICETREE_remove_revpi = "overlays/2xmcp2517fd.dtbo"
+KERNEL_DEVICETREE_remove_revpi = "overlays/rpi-poe-plus.dtbo"
 
 # the following overlays were added only for linux-raspberrypi so let's remove them for Revolution Pi boards which use linux-kunbus
 KERNEL_DEVICETREE_remove_revpi = "overlays/hyperpixel4-pi3.dtbo overlays/hyperpixel4-pi4.dtbo overlays/hyperpixel4-square-pi3.dtbo overlays/hyperpixel4-square-pi4.dtbo"


### PR DESCRIPTION
Include the PoE+ overlay to rootfs for supporting this newer hat

Changelog-entry: Add Raspberry Pi PoE+ overlay to rootfs
Signed-off-by: Florin Sarbu <florin@balena.io>