### PR TITLE
Add fbtft dtoverlay for SPI-connected displays

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -62,6 +62,7 @@ KERNEL_DEVICETREE:append = " \
     overlays/enc28j60.dtbo \
     overlays/enc28j60-spi2.dtbo \
     overlays/exc3000.dtbo \
+    overlays/fbtft.dtbo \
     overlays/fe-pi-audio.dtbo \
     overlays/fsm-demo.dtbo \
     overlays/ghost-amp.dtbo \
@@ -313,6 +314,7 @@ KERNEL_DEVICETREE:remove:revpi = "overlays/2xmcp2517fd.dtbo"
 KERNEL_DEVICETREE:remove:revpi = "overlays/rpi-poe-plus.dtbo"
 KERNEL_DEVICETREE:remove:revpi = "overlays/vc4-kms-dsi-7inch.dtbo"
 KERNEL_DEVICETREE:remove:revpi = "overlays/edt-ft5406.dtbo"
+KERNEL_DEVICETREE:remove:revpi = "overlays/fbtft.dtbo"
 KERNEL_DEVICETREE:remove:revpi = "bcm2708-rpi-b-rev1.dtb"
 KERNEL_DEVICETREE:remove:revpi = "bcm2711-rpi-400.dtb"
 KERNEL_DEVICETREE:remove:revpi = "bcm2711-rpi-cm4.dtb"


### PR DESCRIPTION
Add fbtft for SPI-connected displays
https://github.com/notro/fbtft/wiki/FBTFT-RPI-overlays

Change-type: minor
Changelog-entry: conf/layer: Add fbtft overlay for SPI-connected displays
Signed-off-by: Rahul Thakoor <rahul@balena.io>