### PR TITLE
balena-linux-firmware: Do not compress non-binary txt files

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_%.bbappend
@@ -27,8 +27,8 @@ RREPLACES_${PN}-bcm43456 = " \
 fakeroot do_firmware_compression () {
     if [ "${FIRMWARE_COMPRESSION}" = "1" ]; then
         bbnote "Compressing firmware files"
-        find "${D}${nonarch_base_libdir}/firmware" -type l -exec sh -c 'target=$(readlink "$0"); ln -sf "${target}.xz" "$0"; mv "$0" "$0".xz' {} \;
-        find "${D}${nonarch_base_libdir}/firmware" -path "*/amd-ucode" -prune -o -type f -print -exec xz -C crc32 {} \;
+        find "${D}${nonarch_base_libdir}/firmware" -type l -not -name "*.txt" -exec sh -c 'target=$(readlink "$0"); ln -sf "${target}.xz" "$0"; mv "$0" "$0".xz' {} \;
+        find "${D}${nonarch_base_libdir}/firmware" -path "*/amd-ucode" -prune -not -name "*.txt" -o -type f -print -exec xz -C crc32 {} \;
     fi
 }
 addtask firmware_compression after do_install before do_package


### PR DESCRIPTION
Some device types like the RaspberryPi place non-firmware files under
`/lib/firmware`. This commit skips compression for them.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>