### PR TITLE
raspberrypi0-2w-64: Rename Wifi to W in coffee file

### DIFF
--- a/raspberrypi0-2w-64.coffee
+++ b/raspberrypi0-2w-64.coffee
@@ -4,7 +4,7 @@ deviceTypesCommon = require '@resin.io/device-types/common'
 module.exports =
 	version: 1
 	slug: 'raspberrypi0-2w-64'
-	name: 'Raspberry Pi Zero 2 Wifi (64bit)'
+	name: 'Raspberry Pi Zero 2 W (64bit)'
 	arch: 'aarch64'
 	state: 'released'
 	isDefault: true


### PR DESCRIPTION
Contracts PR [284](https://github.com/balena-io/contracts/pull/284) changed the name of the
device from Raspberry Pi Zero 2 Wifi to Raspberry Pi 0
2 W, let's update this in the coffee file too.

Changelog-entry: raspberrypi0-2w-64: Rename Wifi to W in coffee file
Signed-off-by: Alexandru Costache <alexandru@balena.io>


Fixes https://github.com/balena-os/balena-raspberrypi/issues/790