### PR TITLE
conf/layer: Include camera module dtoverlays

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -104,8 +104,11 @@ KERNEL_DEVICETREE:append = " \
     overlays/i2c6.dtbo \
     overlays/i2s-gpio28-31.dtbo \
     overlays/ilitek251x.dtbo \
+    overlays/imx219.dtbo \
     overlays/imx290.dtbo \
+    overlays/imx378.dtbo \
     overlays/imx477.dtbo \
+    overlays/imx519.dtbo \
     overlays/iqaudio-codec.dtbo \
     overlays/iqaudio-digi-wm8804-audio.dtbo \
     overlays/irs1125.dtbo \
@@ -265,9 +268,12 @@ KERNEL_DEVICETREE:remove:revpi = "overlays/cma.dtbo"
 KERNEL_DEVICETREE:remove:revpi = "overlays/fsm-demo.dtbo \
     overlays/ghost-amp.dtbo"
 KERNEL_DEVICETREE:remove:revpi = "overlays/highperi.dtbo"
-KERNEL_DEVICETREE:remove:revpi = "overlays/imx290.dtbo \
+KERNEL_DEVICETREE:remove:revpi = "overlays/imx219.dtbo \
+    overlays/imx290.dtbo \
     overlays/imx290_327.dtbo \
+    overlays/imx378.dtbo \
     overlays/imx477.dtbo \
+    overlays/imx519.dtbo \
     overlays/iqaudio-codec.dtbo"
 KERNEL_DEVICETREE:remove:revpi = "overlays/irs1125.dtbo \
     overlays/jedec-spi-nor.dtbo \


### PR DESCRIPTION
Add required dtoverlays for camera modules as per [documentation](https://www.raspberrypi.com/documentation/accessories/camera.html#getting-started)

Changelog-entry: conf/layer: Include camera module dtoverlays
Signed-off-by: Rahul Thakoor <rahul@balena.io>