### PR TITLE
conf/layer: Include vc4-fkms-v3d-pi4 overlay

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -208,6 +208,7 @@ KERNEL_DEVICETREE_append = " \
     overlays/upstream.dtbo \
     overlays/upstream-pi4.dtbo \
     overlays/vc4-fkms-v3d.dtbo \
+    overlays/vc4-fkms-v3d-pi4.dtbo \
     overlays/vc4-kms-kippah-7inch.dtbo \
     overlays/vc4-kms-v3d-pi4.dtbo \
     overlays/vc4-kms-dsi-7inch.dtbo \
@@ -308,6 +309,7 @@ KERNEL_DEVICETREE_remove_revpi = "overlays/2xmcp2517fd.dtbo"
 KERNEL_DEVICETREE_remove_revpi = "overlays/rpi-poe-plus.dtbo"
 KERNEL_DEVICETREE_remove_revpi = "overlays/vc4-kms-dsi-7inch.dtbo"
 KERNEL_DEVICETREE_remove_revpi = "overlays/edt-ft5406.dtbo"
+KERNEL_DEVICETREE_remove_revpi = "overlays/vc4-fkms-v3d-pi4.dtbo"
 
 # the following overlays were added only for linux-raspberrypi so let's remove them for Revolution Pi boards which use linux-kunbus
 KERNEL_DEVICETREE_remove_revpi = "overlays/hyperpixel4-pi3.dtbo overlays/hyperpixel4-pi4.dtbo overlays/hyperpixel4-square-pi3.dtbo overlays/hyperpixel4-square-pi4.dtbo"


### PR DESCRIPTION
Until the patch from Michal gets merged in
upstream meta-raspberrypi we can include
the overlay on our side to solve fkms not
loading properly. When this overlay
is not included vcdbg displays
the following error:

    007119.598: Failed to load overlay 'vc4-fkms-v3d'

Changelog-entry: conf/layer: Include vc4-fkms-v3d-pi4 overlay
Signed-off-by: Alexandru Costache <alexandru@balena.io>
Signed-off-by: Florin Sarbu <florin@balena.io>