### PR TITLE
u-boot: Ensure uart retry count is stored in data section

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-avoid-block-uart-write.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-avoid-block-uart-write.patch
@@ -24,7 +24,7 @@ index bd1d89ec83..bd033d14c4 100644
  	struct bcm283x_mu_regs *regs;
  };
 -
-+static uint16_t putc_retry;
++static uint16_t putc_retry __section(".data");
  static int bcm283x_mu_serial_getc(struct udevice *dev);
  
  static int bcm283x_mu_serial_setbrg(struct udevice *dev, int baudrate)

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/serial_pl01x-Add-retry-limit-when-writing-to-uart-co.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/serial_pl01x-Add-retry-limit-when-writing-to-uart-co.patch
@@ -22,7 +22,7 @@ index 6e5d81ce34..22d985f96c 100644
  
  #endif
  
-+static uint16_t putc_retry;
++static uint16_t putc_retry __section(".data");
  static int pl01x_putc(struct pl01x_regs *regs, char c)
  {
  	/* Wait until there is space in the FIFO */


### PR DESCRIPTION
The Pi3 32bit currently refuses to boot if
gpu_mem is set to 396MB. This seems to be caused
by a variable we use in u-boot to avoid locking
while writing to the uart, if enable_uart is
disabled in config.txt.

Having the putc_retry variable uninitialized
meant that it was part of the data section,
however this no longer seems to be the case and
we need to allocate it in .data explicitly.

Changelog-entry: u-boot: fix Pi3 booting with large gpu_mem
Signed-off-by: Alexandru Costache <alexandru@balena.io>