### PR TITLE
unipi-kernel-modules.bb: Switch SRC_URI

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/unipi-kernel-modules/unipi-kernel-modules.bb
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/unipi-kernel-modules/unipi-kernel-modules.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 inherit module
 
 SRC_URI = " \
-	git://git.unipi.technology/UniPi/unipi-kernel.git;protocol=https \
+	git://github.com/UniPiTechnology/unipi-kernel.git;protocol=https \
 	file://0001-Fix-compile-on-kernel-5.10.patch \
 "
 


### PR DESCRIPTION
The vendor now redirects
https://git.unipi.technology/UniPi
to https://github.com/UniPiTechnology/
so let's follow suite.

Changelog-entry: Use updated SRC_URI for unipi kernel modules
Signed-off-by: Florin Sarbu <florin@balena.io>