### PR TITLE
linux-raspberrypi: Add IIO pressure kernel drivers

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.15.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.15.bbappend
@@ -199,6 +199,11 @@ BALENA_CONFIGS[optimize-size] = " \
     CONFIG_CC_OPTIMIZE_FOR_SIZE=y \
 "
 
+BALENA_CONFIGS:append = " iio_pressure_drivers"
+BALENA_CONFIGS[iio_pressure_drivers] = " \
+    CONFIG_BMP280=m \
+"
+
 # Fix dtbo loading on 64bits,
 # see commit 949b88bb for details
 get_cc_option () {


### PR DESCRIPTION
These have been requested by customers to use with their applications.

Fixes #821

Changelog-entry: Add IIO pressure kernel drivers
Signed-off-by: Alex Gonzalez <alexg@balena.io>