### PR TITLE
sd8887-nsp: Avoid build warning removing trailing slash from source var

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/sd8887-nxp/sd8887-nxp.bb
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/sd8887-nxp/sd8887-nxp.bb
@@ -9,7 +9,7 @@ SRC_URI = " \
     file://COPYING \
 "
 
-S = "${WORKDIR}/git/software/drivers/sd8887/"
+S = "${WORKDIR}/git/software/drivers/sd8887"
 
 DEPENDS = "bc-native"
 


### PR DESCRIPTION
This avoids the following build warning:

WARNING: /build/balena-raspberrypi/build/../layers/meta-balena-raspberrypi/recipes-kernel/sd8887-nxp/sd8887-nxp.bb: Recipe sd8887-nxp sets B variable with trailing slash '/build/balena-raspberrypi/build/tmp/work/raspberrypi4_64-poky-linux/sd8887-nxp/1.0-r0/git/software/drivers/sd8887/', remove it

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>