### PR TITLE
linux-raspberrypi: Enable NFSv4 config

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.10.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.10.bbappend
@@ -185,6 +185,14 @@ BALENA_CONFIGS[rtrpi300cfgs] = " \
     CONFIG_CH432T_SPI=m \
 "
 
+BALENA_CONFIGS:append = " nfsfs"
+BALENA_CONFIGS[nfsfs] = " \
+    CONFIG_NFS_FS=m \
+    CONFIG_NFS_V2=m \
+    CONFIG_NFS_V3=m \
+    CONFIG_NFS_V4=m \
+"
+
 # The Pi3-64 and Pi4-64 are the only boards very low on rootfs space for now
 # so we add this as per https://github.com/balena-os/meta-balena/pull/2411
 BALENA_CONFIGS:append:raspberrypi4-64 = " optimize-size"

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.10.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.10.bbappend
@@ -188,9 +188,12 @@ BALENA_CONFIGS[rtrpi300cfgs] = " \
 BALENA_CONFIGS:append = " nfsfs"
 BALENA_CONFIGS[nfsfs] = " \
     CONFIG_NFS_FS=m \
-    CONFIG_NFS_V2=m \
-    CONFIG_NFS_V3=m \
-    CONFIG_NFS_V4=m \
+    CONFIG_NFS_V2=y \
+    CONFIG_NFS_V3=y \
+    CONFIG_NFS_V4=y \
+    CONFIG_NFSD=m \
+    CONFIG_NFSD_V3=y \
+    CONFIG_NFSD_V4=y \
 "
 
 # The Pi3-64 and Pi4-64 are the only boards very low on rootfs space for now


### PR DESCRIPTION
Changelog-entry: linux-raspberrypi: Enable NFSv4 config
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/balena-os/balena-raspberrypi/issues/892