### PR TITLE
bblayers: Modify layer ordering

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/samples/bblayers.conf.sample
+++ b/layers/meta-balena-raspberrypi/conf/samples/bblayers.conf.sample
@@ -6,6 +6,10 @@ BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS ?= " \
+    ${TOPDIR}/../layers/meta-balena/meta-balena-rust \
+    ${TOPDIR}/../layers/meta-balena/meta-balena-common \
+    ${TOPDIR}/../layers/meta-balena/meta-balena-honister \
+    ${TOPDIR}/../layers/meta-balena-raspberrypi \
     ${TOPDIR}/../layers/poky/meta \
     ${TOPDIR}/../layers/poky/meta-poky \
     ${TOPDIR}/../layers/meta-openembedded/meta-oe \
@@ -13,8 +17,4 @@ BBLAYERS ?= " \
     ${TOPDIR}/../layers/meta-openembedded/meta-networking \
     ${TOPDIR}/../layers/meta-openembedded/meta-python \
     ${TOPDIR}/../layers/meta-raspberrypi \
-    ${TOPDIR}/../layers/meta-balena/meta-balena-common \
-    ${TOPDIR}/../layers/meta-balena/meta-balena-honister \
-    ${TOPDIR}/../layers/meta-balena-raspberrypi \
-    ${TOPDIR}/../layers/meta-rust \
     "


### PR DESCRIPTION
Yocto classes and conf files ignore layer priorities and are parsed
in order instead.

Changelog-entry: Modify layer ordering
Signed-off-by: Alex Gonzalez <alexg@balena.io>
