### PR TITLE
Kunbus revpi-connect-s support

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -132,6 +132,7 @@ RPI_KERNEL_DEVICETREE:append:raspberrypi3-64 = " broadcom/bcm2710-rpi-cm3.dtb"
 
 RPI_KERNEL_DEVICETREE:append:raspberrypi4-64 = " broadcom/bcm2711-rpi-400.dtb"
 RPI_KERNEL_DEVICETREE:append:raspberrypi4-64 = " broadcom/bcm2711-rpi-cm4.dtb"
+RPI_KERNEL_DEVICETREE:append:raspberrypi4-64 = " broadcom/bcm2711-rpi-cm4s.dtb"
 
 PREFERRED_VERSION:linux-raspberrypi = "5.10.%"
 

--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -145,3 +145,4 @@ IWLWIFI_FW_TOCLEAN:raspberrypi0-2w-64 = ""
 
 KERNEL_FEATURES:remove:revpi-core-3 = "cfg/fs/vfat.scc"
 KERNEL_FEATURES:remove:revpi-connect = "cfg/fs/vfat.scc"
+KERNEL_FEATURES:remove:revpi-connect-s = "cfg/fs/vfat.scc"

--- a/layers/meta-balena-raspberrypi/conf/machine/include/revpi4.inc
+++ b/layers/meta-balena-raspberrypi/conf/machine/include/revpi4.inc
@@ -1,0 +1,14 @@
+MACHINEOVERRIDES = "raspberrypi4-64:${MACHINE}"
+include conf/machine/raspberrypi4-64.conf
+
+# because we override the raspberrypi4-64 machine which in turn is an override of raspberrypi4, we need to do the following gimmick:
+# courtesy of https://github.com/balena-os/balena-jetson/pull/112/commits/9d21df6899e595b4aeab4cc9a939ae6c564c669a
+MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':raspberrypi4-64:${MACHINE}')}"
+
+SOC_FAMILY = "rpi:revpi"
+
+PREFERRED_PROVIDER_virtual/kernel = "linux-kunbus"
+
+KERNEL_MODULE_AUTOLOAD += "piControl"
+
+IMAGE_INSTALL:append = " picontrol"

--- a/layers/meta-balena-raspberrypi/conf/machine/revpi-connect-s.conf
+++ b/layers/meta-balena-raspberrypi/conf/machine/revpi-connect-s.conf
@@ -1,0 +1,11 @@
+#@TYPE: Machine
+#@NAME: Revolution Pi Connect S
+#@DESCRIPTION: Machine configuration for Revolution Pi Connect S board
+
+require conf/machine/include/revpi4.inc
+
+KERNEL_DEVICETREE:append = " \
+	overlays/revpi-connect.dtbo \
+	overlays/revpi-connect-dt-blob-overlay.dtb \
+	overlays/revpi-connect-can.dtbo \
+"

--- a/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
+++ b/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
@@ -26,6 +26,7 @@ DISABLE_VC4GRAPHICS = "1"
 DISABLE_VC4GRAPHICS:remove:raspberrypi3-64 = "1"
 DISABLE_VC4GRAPHICS:remove:raspberrypi4-64 = "1"
 DISABLE_VC4GRAPHICS:remove:raspberrypi0-2w-64 = "1"
+DISABLE_VC4GRAPHICS:remove:revpi-connect-s = "1"
 
 # RPI BSP uses uncompressed kernel images by default
 KERNEL_IMAGETYPE="zImage"

--- a/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
+++ b/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
@@ -4,6 +4,7 @@
 #MACHINE ?= "raspberrypi3"
 #MACHINE ?= "raspberrypi3-64"
 #MACHINE ?= "revpi-connect"
+#MACHINE ?= "revpi-connect-s"
 #MACHINE ?= "revpi-core-3"
 #MACHINE ?= "raspberrypi4-64"
 #MACHINE ?= "raspberrypi400-64"

--- a/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -28,6 +28,14 @@ do_deploy:append:revpi-connect() {
 	echo "dtoverlay=revpi-connect" >> ${DEPLOYDIR}/bootfiles/config.txt
 }
 
+do_deploy:append:revpi-connect-s() {
+	# Use the RevPi Connect device tree overlay
+	echo "dtoverlay=revpi-connect" >> ${DEPLOYDIR}/bootfiles/config.txt
+        echo "dtoverlay=dwc2" >> ${DEPLOYDIR}/bootfiles/config.txt
+        echo "dr_mode=host" >> ${DEPLOYDIR}/bootfiles/config.txt
+
+}
+
 do_deploy:append:raspberrypi3-unipi-neuron() {
 	# Use the dt overlays required by the UniPi Neuron family of boards
 	echo "dtoverlay=neuronee" >> ${DEPLOYDIR}/bootfiles/config.txt

--- a/layers/meta-balena-raspberrypi/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/images/balena-image.bbappend
@@ -11,6 +11,12 @@ SDIMG_KERNELIMAGE:raspberrypi2 ?= "kernel7.img"
 SDIMG_KERNELIMAGE:raspberrypi3-64 ?= "kernel8.img"
 SDIMG_KERNELIMAGE:raspberrypi0-2w-64 ?= "kernel8.img"
 
+# Increase Root File system size
+IMAGE_ROOTFS_SIZE:revpi-connect-s ?= "319488"
+IMAGE_OVERHEAD_FACTOR:revpi-connect-s ?= "1.0"
+IMAGE_ROOTFS_EXTRA_SPACE:revpi-connect-s ?= "53248"
+IMAGE_ROOTFS_MAXSIZE:revpi-connect-s ?= "372736"
+
 # Customize balenaos-img
 BALENA_IMAGE_BOOTLOADER:rpi = "rpi-bootfiles"
 BALENA_BOOT_PARTITION_FILES:rpi = " \
@@ -22,6 +28,8 @@ BALENA_BOOT_PARTITION_FILES:rpi = " \
 BALENA_BOOT_PARTITION_FILES:append:revpi-core-3 = " revpi-core-dt-blob-overlay.dtb:/dt-blob.bin"
 
 BALENA_BOOT_PARTITION_FILES:append:revpi-connect = " revpi-connect-dt-blob-overlay.dtb:/dt-blob.bin"
+
+BALENA_BOOT_PARTITION_FILES:append:revpi-connect-s = " revpi-connect-dt-blob-overlay.dtb:/dt-blob.bin"
 
 python overlay_dtbs_handler () {
     # Add all the dtb files programatically

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus_%.bbappend
@@ -6,6 +6,10 @@ SRC_URI:append:revpi-connect = " \
     file://0001-Add-revpi-connect-can-overlay.patch \
 "
 
+SRC_URI:append:revpi-connect-s = " \
+    file://0001-Add-revpi-connect-can-overlay.patch \
+"
+
 # Set console accordingly to build type
 CMDLINE = "dwc_otg.lpm_enable=0 rootwait"
 CMDLINE += "${@bb.utils.contains('DISTRO_FEATURES','osdev-image',"console=tty1 console=serial0,115200"," vt.global_cursor_default=0 console=null",d)}"

--- a/layers/meta-balena-raspberrypi/recipes-kernel/picontrol/picontrol/0001-Use-modules_install-as-wanted-by-yocto.patch
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/picontrol/picontrol/0001-Use-modules_install-as-wanted-by-yocto.patch
@@ -15,7 +15,7 @@ index 56eab93..6d78b95 100644
 +++ b/Makefile
 @@ -44,6 +44,9 @@ EXTRA_CFLAGS += -D__KUNBUSPI_KERNEL__
  all: compiletime.h
- 	$(MAKE) ARCH=arm CROSS_COMPILE="$(CROSS_COMPILE)" -C $(KDIR) M=$(PWD)  modules
+ 	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE="$(CROSS_COMPILE)" -C $(KDIR) M=$(PWD)  modules
 
 +modules_install:
 +	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE="$(CROSS_COMPILE)" -C $(KDIR) M=$(PWD)  modules_install

--- a/revpi-connect-s.coffee
+++ b/revpi-connect-s.coffee
@@ -1,0 +1,45 @@
+deviceTypesCommon = require '@resin.io/device-types/common'
+{ networkOptions, commonImg, instructions } = deviceTypesCommon
+
+REVPI_DEBUG = "While not having the Revolution Pi board powered, connect your system to the board's USB port via a micro-USB cable."
+REVPI_POWER = "Power on the Revolution Pi board."
+REVPI_WRITE = "Write the OS to the internal MMC storage device. We recommend using <a href=http://www.etcher.io/>Etcher</a>."
+REVPI_POWEROFF = "When flashing is complete, power off the board and unplug the micro-USB cable."
+
+module.exports =
+	version: 1
+	slug: 'revpi-connect-s'
+	name: 'Revolution Pi Connect S'
+	arch: 'aarch64'
+	state: 'new'
+
+	instructions: [
+		REVPI_DEBUG
+		REVPI_POWER
+		REVPI_WRITE
+		REVPI_POWEROFF
+		instructions.CONNECT_AND_BOOT
+	]
+
+	gettingStartedLink:
+		windows: 'https://docs.resin.io/raspberrypi3/nodejs/getting-started/#adding-your-first-device'
+		osx: 'https://docs.resin.io/raspberrypi3/nodejs/getting-started/#adding-your-first-device'
+		linux: 'https://docs.resin.io/raspberrypi3/nodejs/getting-started/#adding-your-first-device'
+
+	options: [ networkOptions.group ]
+
+	yocto:
+		machine: 'revpi-connect-s'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
+		version: 'yocto-kirkstone'
+		deployArtifact: 'balena-image-revpi-connect-s.balenaos-img'
+		compressed: true
+
+	configuration:
+		config:
+			partition:
+				primary: 1
+			path: '/config.json'
+
+	initialization: commonImg.initialization


### PR DESCRIPTION
Dear community,

since we have a Kunbus Revolution Pi Connect S and want to flash it with balenaOS, we figured we have to build an image for it since none of the available ones actually did work (the closest was the Raspberry Pi 4 image which failed to boot completely because of a different device tree – so we think).

Our attempt now is to build a new image based on the `revpi-connect` setup. We replicated this, saved it as `revpi-connect-s` and added CM4s support to the best of our knowledge.

We're now stuck in the build process when the linux-kunbus kernel is being compiled with the following error message:

`No rule to make target 'arch/arm64/boot/dts/broadcom/bcm2711-rpi-400.dtb'.`

Full output below.

Any push into the right direction is greatly appreciated as we reckon more people would like to see support for the Revolution Pi Connect S.

Disclaimer: we know that some of the proposed changes could kill the `revpi-connect` build, but we're focussing on support for the `revpi-connect-s` first, get this to run and then isolate it properly :)

```$ ./balena-yocto-scripts/build/barys -m revpi-connect-s
Building JSON manifest...
audited 3 packages in 1.826s
found 0 vulnerabilities

...Done

  _           _                   ___  ____
 | |__   __ _| | ___ _ __   __ _ / _ \/ ___|
 | '_ \ / _` | |/ _ \ '_ \ / _` | | | \___ \
 | |_) | (_| | |  __/ | | | (_| | |_| |___) |
 |_.__/ \__,_|_|\___|_| |_|\__,_|\___/|____/

 -------------------------------------------- 

Resin specific images available:
	balena-image

Balena Fin (CM3)                         : $ MACHINE=fincm3 bitbake balena-image
NPE X500 M3                              : $ MACHINE=npe-x500-m3 bitbake balena-image
Raspberry Pi (v1 / Zero / Zero W)        : $ MACHINE=raspberrypi bitbake balena-image
Raspberry Pi Zero 2 W (64bit)            : $ MACHINE=raspberrypi0-2w-64 bitbake balena-image
Raspberry Pi 2                           : $ MACHINE=raspberrypi2 bitbake balena-image
Raspberry Pi 3 (using 64bit OS)          : $ MACHINE=raspberrypi3-64 bitbake balena-image
UniPi Neuron (Raspberry Pi 3) (NEW)      : $ MACHINE=raspberrypi3-unipi-neuron bitbake balena-image
Raspberry Pi 3                           : $ MACHINE=raspberrypi3 bitbake balena-image
Raspberry Pi 4                           : $ MACHINE=raspberrypi4-64 bitbake balena-image
Raspberry Pi 400 (NEW)                   : $ MACHINE=raspberrypi400-64 bitbake balena-image
Raspberry Pi CM4 IO Board (NEW)          : $ MACHINE=raspberrypicm4-ioboard bitbake balena-image
Revolution Pi Connect S (NEW)            : $ MACHINE=revpi-connect-s bitbake balena-image
Revolution Pi Connect (NEW)              : $ MACHINE=revpi-connect bitbake balena-image
Revolution Pi Core 3                     : $ MACHINE=revpi-core-3 bitbake balena-image
Rocktech-RPI-300 (NEW)                   : $ MACHINE=rt-rpi-300 bitbake balena-image

[000000009][LOG]Release honister already supported by device integration layer, will not revert meta-balena-common syntax.
[000000009][LOG]BalenaOS build initialized in directory: build.
[000000009][LOG]Run build for revpi-connect-s: MACHINE=revpi-connect-s bitbake balena-image 
[000000009][LOG]This might take a while ...
Loading cache: 100% |############################################################################################################################################################################| Time: 0:00:00
Loaded 3870 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.52.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-poky-linux"
MACHINE              = "revpi-connect-s"
DISTRO               = "balena-os"
DISTRO_VERSION       = "2.101.7"
TUNE_FEATURES        = "aarch64 armv8a crc crypto cortexa72"
TARGET_FPU           = ""
meta-balena-rust     = "HEAD:d4384db8c3f0aa01732627f92fc3d446359bf743"
meta-balena-common   
meta-balena-honister = "HEAD:61b53fbb8b667de54707cc6aa94fd79674958856"
meta-balena-raspberrypi = "master:3d21d351597a598aa03add6c59cd576fcfcb7123"
meta                 
meta-poky            = "HEAD:43cfa130d9e72cec421dd1530858926b7445752d"
meta-oe              
meta-filesystems     
meta-networking      
meta-python          = "HEAD:e886fc0cbac89998f675b70679d0cce6bcebfb7f"
meta-raspberrypi     = "HEAD:378d4b6e7ba64b6a9a701457cc3780fa896ba5dc"

Initialising tasks: 100% |#######################################################################################################################################################################| Time: 0:00:01
Sstate summary: Wanted 392 Local 1 Network 0 Missed 391 Current 1461 (0% match, 78% complete)
NOTE: Executing Tasks
ERROR: linux-kunbus-1_4.19.95+gitAUTOINC+54d60ba30a-r0 do_compile: oe_runmake failed
ERROR: linux-kunbus-1_4.19.95+gitAUTOINC+54d60ba30a-r0 do_compile: ExecutionError('/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/temp/run.do_compile.627008', 1, None, None)
ERROR: Logfile of failure stored in: /home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/temp/log.do_compile.627008
Log data follows:
| DEBUG: Executing python function do_overlays
| /home/ubuntu/balena-raspberrypi/build/tmp/work-shared/revpi-connect-s/kernel-source/arch/arm64/boot/dts/overlays/*-overlay.dts
| exec_func_python() autogenerated:2: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/ubuntu/balena-raspberrypi/build/tmp/deploy/images/revpi-connect-s/overlays.txt' mode='w' encoding='UTF-8'>
| ResourceWarning: Enable tracemalloc to get the object allocation traceback
| DEBUG: Python function do_overlays finished
| DEBUG: Executing shell function do_compile
| NOTE: KBUILD_BUILD_TIMESTAMP: Tue Jun 16 03:38:31 UTC 2020
| NOTE: make -j 16 HOSTCC=gcc  -isystem/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/include -O2 -pipe -L/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -L/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,--enable-new-dtags                         -Wl,-rpath-link,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath-link,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,-rpath,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,-O1 -Wl,--allow-shlib-undefined -Wl,--dynamic-linker=/home/ubuntu/balena-raspberrypi/build/tmp/sysroots-uninative/x86_64-linux/lib/ld-linux-x86-64.so.2 HOSTCPP=gcc  -E HOSTCXX=g++  -isystem/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/include -O2 -pipe -L/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -L/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,--enable-new-dtags                         -Wl,-rpath-link,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath-link,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,-rpath,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,-O1 -Wl,--allow-shlib-undefined -Wl,--dynamic-linker=/home/ubuntu/balena-raspberrypi/build/tmp/sysroots-uninative/x86_64-linux/lib/ld-linux-x86-64.so.2 Image.gz CC=aarch64-poky-linux-gcc   -fuse-ld=bfd -fmacro-prefix-map=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0=/usr/src/debug/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0                      -fdebug-prefix-map=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0=/usr/src/debug/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0                      -fdebug-prefix-map=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot=                      -fdebug-prefix-map=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native=  -fdebug-prefix-map=/home/ubuntu/balena-raspberrypi/build/tmp/work-shared/revpi-connect-s/kernel-source=/usr/src/kernel  --sysroot=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot LD=aarch64-poky-linux-ld.bfd    --sysroot=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot LOADADDR=0x00008000
|   GEN     ./Makefile
| scripts/kconfig/conf  --syncconfig Kconfig
|   GEN     ./Makefile
|   Using /home/ubuntu/balena-raspberrypi/build/tmp/work-shared/revpi-connect-s/kernel-source as source for kernel
|   CALL    /home/ubuntu/balena-raspberrypi/build/tmp/work-shared/revpi-connect-s/kernel-source/scripts/checksyscalls.sh
|   CHK     include/generated/compile.h
|   GZIP    kernel/config_data.gz
| NOTE: make -j 16 HOSTCC=gcc  -isystem/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/include -O2 -pipe -L/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -L/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,--enable-new-dtags                         -Wl,-rpath-link,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath-link,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,-rpath,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,-O1 -Wl,--allow-shlib-undefined -Wl,--dynamic-linker=/home/ubuntu/balena-raspberrypi/build/tmp/sysroots-uninative/x86_64-linux/lib/ld-linux-x86-64.so.2 HOSTCPP=gcc  -E HOSTCXX=g++  -isystem/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/include -O2 -pipe -L/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -L/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,--enable-new-dtags                         -Wl,-rpath-link,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath-link,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,-rpath,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,-O1 -Wl,--allow-shlib-undefined -Wl,--dynamic-linker=/home/ubuntu/balena-raspberrypi/build/tmp/sysroots-uninative/x86_64-linux/lib/ld-linux-x86-64.so.2 broadcom/bcm2711-rpi-4-b.dtb CC=aarch64-poky-linux-gcc   -fuse-ld=bfd -fmacro-prefix-map=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0=/usr/src/debug/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0                      -fdebug-prefix-map=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0=/usr/src/debug/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0                      -fdebug-prefix-map=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot=                      -fdebug-prefix-map=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native=  -fdebug-prefix-map=/home/ubuntu/balena-raspberrypi/build/tmp/work-shared/revpi-connect-s/kernel-source=/usr/src/kernel  --sysroot=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot   LD=aarch64-poky-linux-ld.bfd    --sysroot=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot LOADADDR=0x00008000
|   GEN     ./Makefile
| scripts/kconfig/conf  --syncconfig Kconfig
| NOTE: make -j 16 HOSTCC=gcc  -isystem/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/include -O2 -pipe -L/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -L/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,--enable-new-dtags                         -Wl,-rpath-link,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath-link,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,-rpath,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,-O1 -Wl,--allow-shlib-undefined -Wl,--dynamic-linker=/home/ubuntu/balena-raspberrypi/build/tmp/sysroots-uninative/x86_64-linux/lib/ld-linux-x86-64.so.2 HOSTCPP=gcc  -E HOSTCXX=g++  -isystem/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/include -O2 -pipe -L/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -L/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,--enable-new-dtags                         -Wl,-rpath-link,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath-link,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,-rpath,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath,/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native/lib                         -Wl,-O1 -Wl,--allow-shlib-undefined -Wl,--dynamic-linker=/home/ubuntu/balena-raspberrypi/build/tmp/sysroots-uninative/x86_64-linux/lib/ld-linux-x86-64.so.2 broadcom/bcm2711-rpi-400.dtb CC=aarch64-poky-linux-gcc   -fuse-ld=bfd -fmacro-prefix-map=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0=/usr/src/debug/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0                      -fdebug-prefix-map=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0=/usr/src/debug/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0                      -fdebug-prefix-map=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot=                      -fdebug-prefix-map=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot-native=  -fdebug-prefix-map=/home/ubuntu/balena-raspberrypi/build/tmp/work-shared/revpi-connect-s/kernel-source=/usr/src/kernel  --sysroot=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot   LD=aarch64-poky-linux-ld.bfd    --sysroot=/home/ubuntu/balena-raspberrypi/build/tmp/work/revpi_connect_s-poky-linux/linux-kunbus/1_4.19.95+gitAUTOINC+54d60ba30a-r0/recipe-sysroot LOADADDR=0x00008000
| make[3]: *** No rule to make target 'arch/arm64/boot/dts/broadcom/bcm2711-rpi-400.dtb'.  Stop.
| make[2]: *** [arch/arm64/Makefile:132: broadcom/bcm2711-rpi-400.dtb] Error 2
| make[1]: *** [Makefile:146: sub-make] Error 2
| make: *** [Makefile:24: __sub-make] Error 2
| ERROR: oe_runmake failed
| WARNING: exit code 1 from a shell command.
ERROR: Task (/home/ubuntu/balena-raspberrypi/build/../layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus.bb:do_compile) failed with exit code '1'
NOTE: Tasks Summary: Attempted 3338 tasks of which 3272 didn't need to be rerun and 1 failed.

Summary: 1 task failed:
  /home/ubuntu/balena-raspberrypi/build/../layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus.bb:do_compile
Summary: There were 2 ERROR messages shown, returning a non-zero exit code.
[000000107][LOG]Build for revpi-connect-s failed. Check failed log in build/tmp/log/cooker/revpi-connect-s .
[000000108][LOG]If build for revpi-connect-s succeeded, final image should have been generated here:
[000000108][LOG]   build/tmp/deploy/images/revpi-connect-s/balena-image-revpi-connect-s.balenaos-img
[000000108][LOG]Done.
```