### PR TITLE
systemd_%.bbappend: Set ShutdownWatchdogSec to 15s

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/systemd/systemd/watchdog_shutdown.conf
+++ b/layers/meta-balena-raspberrypi/recipes-core/systemd/systemd/watchdog_shutdown.conf
@@ -1,0 +1,2 @@
+[Manager]
+ShutdownWatchdogSec=15s

--- a/layers/meta-balena-raspberrypi/recipes-core/systemd/systemd_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:append := ":${THISDIR}/${PN}"
+
+SRC_URI:prepend = " \
+    file://watchdog_shutdown.conf \
+"
+
+do_install:append() {
+    install -d -m 0755 ${D}/${sysconfdir}/systemd/system.conf.d
+    install -m 0644 ${WORKDIR}/watchdog_shutdown.conf ${D}/${sysconfdir}/systemd/system.conf.d
+}


### PR DESCRIPTION
On a rpi4 based board with the broadcom watchdog, systemd complains on reboot:

Failed to set timeout to 600s: Invalid argument

and the board does not seem to actually reboot, instead it freezes.

Changelog-entry: Set ShutdownWatchdogSec to 15 seconds down from 600 to workaround reboot issue on RPi4 based board
Signed-off-by: Florin Sarbu <florin@balena.io>