### PR TITLE
linux-raspberrypi_5.10.bbappend: Enable CONFIG_WATCHDOG_NOWAYOUT

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.10.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.10.bbappend
@@ -220,3 +220,9 @@ do_compile:append() {
         oe_runmake dtbs CC="${KERNEL_CC} $cc_extra " LD="${KERNEL_LD}" ${KERNEL_EXTRA_ARGS}
     fi
 }
+
+# enable watchdog nowayout
+BALENA_CONFIGS:append = " enable-wd-nowayout"
+BALENA_CONFIGS[enable-wd-nowayout] = " \
+    CONFIG_WATCHDOG_NOWAYOUT=y \
+"


### PR DESCRIPTION
If for any reason the userspace watchdog daemon crashes and hence the watchdog device is closed then the system will not reboot. In order to not have a frozen system in such a case, we enable CONFIG_WATCHDOG_NOWAYOUT.

Changelog-entry: Enable CONFIG_WATCHDOG_NOWAYOUT to account for cases when the watchdog userspace daemon crashes
Signed-off-by: Florin Sarbu <florin@balena.io>