### PR TITLE
Fix missing file gpio-poweroff.dtbo

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/images/balena-image.bbappend
@@ -33,6 +33,10 @@ python overlay_dtbs_handler () {
             f = open(d.getVar('DEPLOY_DIR_IMAGE') + '/overlays.txt', "r")
             kernel_devicetree = f.read()
             f.close
+            # Sanity check. Should be removed once the issue is confirmed to be fixed
+            debug_missing_dtbo = 'gpio-poweroff.dtbo'
+            if not debug_missing_dtbo in kernel_devicetree:
+                bb.fatal('Sanity check: ' + debug_missing_dtbo + ' not found in overlay list! Overlays list contents:' + kernel_devicetree)
             d.setVar('KERNEL_DEVICETREE', kernel_devicetree)
             overlay_dtbs = split_overlays(d, 0)
             root_dtbs = split_overlays(d, 1)

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus.bbappend
@@ -84,15 +84,13 @@ python do_overlays() {
     import glob, re
     overlays = []
     source_path = d.getVar('S', True) + '/arch/' + d.getVar('ARCH',True) + '/boot/dts/overlays/*-overlay.dts'
-    print(source_path)
     for overlay in glob.glob(source_path):
         overlays.append(re.sub(r'-overlay.dts','.dtbo',overlay).split('dts/')[-1])
     for dtbo in overlays:
-        kernel_devicetree = d.getVar('KERNEL_DEVICETREE', True)
-        d.setVar('KERNEL_DEVICETREE', kernel_devicetree + '   ' + dtbo)
+        d.setVar('KERNEL_DEVICETREE', d.getVar('KERNEL_DEVICETREE', True) + ' ' + dtbo)
 
     f = open(d.getVar('DEPLOY_DIR_IMAGE') + '/overlays.txt', "w")
-    f.write(kernel_devicetree)
+    f.write(d.getVar('KERNEL_DEVICETREE', True))
     f.close
 }
 

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -14,15 +14,13 @@ python do_overlays() {
     import glob, re
     overlays = []
     source_path = d.getVar('S', True) + '/arch/' + d.getVar('ARCH',True) + '/boot/dts/overlays/*-overlay.dts'
-    print(source_path)
     for overlay in glob.glob(source_path):
         overlays.append(re.sub(r'-overlay.dts','.dtbo',overlay).split('dts/')[-1])
     for dtbo in overlays:
-        kernel_devicetree = d.getVar('KERNEL_DEVICETREE', True)
-        d.setVar('KERNEL_DEVICETREE', kernel_devicetree + '   ' + dtbo)
+        d.setVar('KERNEL_DEVICETREE', d.getVar('KERNEL_DEVICETREE', True) + ' ' + dtbo)
 
     f = open(d.getVar('DEPLOY_DIR_IMAGE') + '/overlays.txt', "w")
-    f.write(kernel_devicetree)
+    f.write(d.getVar('KERNEL_DEVICETREE', True))
     f.close
 }
 


### PR DESCRIPTION
This issue has not been reproduced locally in 3 build attempts, so we need to see if this happens in Jenkins and at what build step.