### PR TITLE
sd8887-nxp: Update to tag 0.11.0 to include newer driver version

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/sd8887-nxp/sd8887-nxp.bb
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/sd8887-nxp/sd8887-nxp.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca
 inherit module
 
 SRC_URI = " \
-    git://github.com/balena-io-hardware/balena-fin.git;protocol=https;tag=v0.9.2 \
+    git://github.com/balena-io-hardware/fin-info-doc.git;protocol=https;tag=v0.11.0 \
     file://COPYING \
 "
 


### PR DESCRIPTION
This is W15.68.19.p59-15.26.19.p59-C4X15698_A2 distribution from NXP.

The Fin repository that includes the driver has a changed name as well.
