### PR TITLE
bluez5: modify patches for v5.66 update

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -3,6 +3,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:remove:fincm3 = "file://0001-bcm43xx-Add-bcm43xx-3wire-variant.patch"
 SRC_URI:remove:fincm3 = "file://0002-bcm43xx-The-UART-speed-must-be-reset-after-the-firmw.patch"
 SRC_URI:remove:fincm3 = "file://0003-Increase-firmware-load-timeout-to-30s.patch"
-SRC_URI:remove:fincm3 = "file://0004-Move-the-43xx-firmware-into-lib-firmware.patch"
+SRC_URI:remove = "file://0004-Move-the-43xx-firmware-into-lib-firmware.patch"
 
 RDEPENDS:${PN}:remove:fincm3 = "pi-bluetooth"


### PR DESCRIPTION
Requires https://github.com/balena-os/meta-balena/pull/2982

Changelog-entry: Modify bluez patches for v5.66 update
Signed-off-by: Alex Gonzalez <alexg@balena.io>