### PR TITLE
rpi-bootfiles.bbappend: Make the firmware filtering generic

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/rpi-bootfiles.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/rpi-bootfiles.bbappend
@@ -14,24 +14,25 @@ do_deploy:append() {
     rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/start_db.elf
     rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/fixup4db.dat
     rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/start4db.elf
-    if [ "${MACHINE}" != "raspberrypi4-64" ] && [ "${MACHINE}" != "rt-rpi-300" ] && [ "${MACHINE}" != "raspberrypi400-64" ] && [ "${MACHINE}" != "raspberrypicm4-ioboard" ] ; then
-        # exclude RaspberryPi4 specific firmware from non raspberrypi4-64 balenaOS builds
-        rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/fixup4.dat
-        rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/fixup4cd.dat
-        rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/fixup4x.dat
-        rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/start4.elf
-        rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/start4cd.elf
-        rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/start4x.elf
-    else
-        # exclude from raspberrypi4-64 balenaOS the binaries which are for previous RaspberryPi versions
+
+    if echo ${MACHINEOVERRIDES} | grep -i "raspberrypi4-64"; then
+        # exclude from raspberrypi4-64 based balenaOS builds the binaries which are for previous RaspberryPi versions
         rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/fixup.dat
         rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/fixup_cd.dat
         rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/fixup_x.dat
         rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/start.elf
         rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/start_cd.elf
         rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/start_x.elf
-	# bootcode.bin is not used anymore on rpi4 as the boot code is now in an EEPROM (https://www.raspberrypi.org/documentation/hardware/raspberrypi/booteeprom.md)
-	rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/bootcode.bin
+        # bootcode.bin is not used anymore on rpi4 as the boot code is now in an EEPROM (https://www.raspberrypi.org/documentation/hardware/raspberrypi/booteeprom.md)
+        rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/bootcode.bin
+    else
+        # exclude RaspberryPi4 specific firmware from non raspberrypi4-64 based balenaOS builds
+        rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/fixup4.dat
+        rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/fixup4cd.dat
+        rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/fixup4x.dat
+        rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/start4.elf
+        rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/start4cd.elf
+        rm -f ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/start4x.elf
     fi
 }
 


### PR DESCRIPTION
We do this so we don't need to always increase this list we check each time we add new raspberrypi4-64 based machines. Instead, we rely on the fact that all new RPI4 based machines will inherit the raspberrypi4-64 machine.

Changelog-entry: Make the boot firmware filtering for rpi4 based hw generic