### PR TITLE
phoenix-peripheral.bb: Fix faulty RDEPENDS

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-extended/phoenix-peripheral/phoenix-peripheral.bb
+++ b/layers/meta-balena-raspberrypi/recipes-extended/phoenix-peripheral/phoenix-peripheral.bb
@@ -10,7 +10,7 @@ S = "${WORKDIR}/git"
 inherit systemd
 
 PACKAGES =+ "${PN}-button-trig ${PN}-lvd-hook ${PN}-gpio-wdt ${PN}-rtc-sync"
-RDEPENDS_${PN}-gpio-wdt += "watchdog"
+RDEPENDS:${PN}-gpio-wdt += "watchdog"
 
 FILES:${PN} = " \
     ${datadir}/phoenix/peripheral/* \


### PR DESCRIPTION
Since we are using Poky Kirkstone we need to use the proper syntax

Changelog-entry: Fix phoenix-peripheral RDEPENDS syntax in order to have watchdog in rootfs for raspberrypi4-superhub