### PR TITLE
Add watchdog for raspberrypi4-superhub

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/images/balena-image.bbappend
@@ -67,6 +67,8 @@ RPI_KERNEL_DEVICETREE:remove:revpi = "bcm2708-rpi-zero-w.dtb bcm2710-rpi-3-b-plu
 IMAGE_ROOTFS_SIZE:raspberrypi4-superhub="409600"
 
 IMAGE_INSTALL:append:raspberrypi4-superhub = " \
+    watchdog \
+    watchdog-config \
     phoenix-peripheral \
     phoenix-peripheral-button-trig \
     phoenix-peripheral-lvd-hook \

--- a/layers/meta-balena-raspberrypi/recipes-extended/phoenix-peripheral/phoenix-peripheral.bb
+++ b/layers/meta-balena-raspberrypi/recipes-extended/phoenix-peripheral/phoenix-peripheral.bb
@@ -3,7 +3,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
  
 SRC_URI = "git://github.com/balena-os/phoenix-peripheral.git;branch=master;protocol=https"
-SRCREV="31cf0f93aca0b2b1e52fc4f48e2baa733b8bd137"
+SRCREV="80aaedf02021246a786f1ba2b8c2bfd04e620c62"
 
 S = "${WORKDIR}/git"
 

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/raspberrypi4-superhub/0002-Add-infineon-tpm-DT-overlay-for-Phoenix-Board.patch
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/raspberrypi4-superhub/0002-Add-infineon-tpm-DT-overlay-for-Phoenix-Board.patch
@@ -33,7 +33,7 @@ index 000000000000..92062e6c2fa0
 +/dts-v1/;
 +/plugin/;
 +/ {
-+    ompatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
++    compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
 +
 +    fragment@0 {
 +        target = <&spi1>;


### PR DESCRIPTION
Add watchdog to superhub image, and update phoenix-peripheral SRCREV.