### PR TITLE
watchdog: Modify watchdog systemd startup for superhub device

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-extended/watchdog/watchdog/0001-Move-watchdog-service-before-networking.patch
+++ b/layers/meta-balena-raspberrypi/recipes-extended/watchdog/watchdog/0001-Move-watchdog-service-before-networking.patch
@@ -1,0 +1,22 @@
+From 39823832c202a61fadae787c534d79ceb0ba7642 Mon Sep 17 00:00:00 2001
+From: Cyrus Chan <cyrus.chan@energybox.com>
+Date: Sun, 23 Jul 2023 21:30:47 +0800
+Subject: [PATCH] Move watchdog service before networking
+
+---
+ debian/watchdog.service | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/debian/watchdog.service b/debian/watchdog.service
+index 50bcecc..70303f1 100644
+--- a/debian/watchdog.service
++++ b/debian/watchdog.service
+@@ -1,6 +1,7 @@
+ [Unit]
+ Description=watchdog daemon
+-After=multi-user.target
++Before=network-pre.target
++Wants=network-pre.target
+ 
+ [Service]
+ Type=forking

--- a/layers/meta-balena-raspberrypi/recipes-extended/watchdog/watchdog_5.16.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-extended/watchdog/watchdog_5.16.bbappend
@@ -1,1 +1,7 @@
 SYSTEMD_AUTO_ENABLE:raspberrypi4-superhub = "enable"
+
+FILESEXTRAPATHS:prepend:raspberrypi4-superhub := "${THISDIR}/${PN}:"
+
+SRC_URI:append:raspberrypi4-superhub = " \
+    file://0001-Move-watchdog-service-before-networking.patch \
+"


### PR DESCRIPTION
This update brings in changes needed to speedup watchdog startup

Changelog-entry: Update watchdog config for superhub device type