### PR TITLE
meta-balena-raspberrypi:layer.conf: Remove redundant UBOOT_MACHINE co…

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -121,8 +121,6 @@ KERNEL_DEVICETREE:remove:revpi = "overlays/hyperpixel4-pi3.dtbo overlays/hyperpi
 # We use udev rules to create serial device aliases
 SERIAL_CONSOLES = "115200;serial0"
 
-UBOOT_MACHINE:raspberrypi4-64 = "rpi_arm64_defconfig"
-
 # Note: We do not include the raspberrypi-400.dtb
 # in the rootfs, raspbian doesn't either. Including it
 # breaks usb boot in u-boot, as well as the usb2.0 port


### PR DESCRIPTION
…nfig

This option is now set from the bsp's layer raspberrypi4-64.conf file.

Changelog-entry: Remove redundant UBOOT_MACHINE setting for raspberrypi4-64