### PR TITLE
initramfs-framework: revpi:remove migrator module

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/images/balena-image-initramfs.bbappend
@@ -1,0 +1,1 @@
+PACKAGE_INSTALL:remove:revpi = "initramfs-module-migrate"

--- a/layers/meta-balena-raspberrypi/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,0 +1,4 @@
+PACKAGES:remove:revpi = "initramfs-module-migrate"
+do_install:append:revpi() {
+	rm -f ${D}/init.d/92-migrate
+}


### PR DESCRIPTION
The Revolution Pi are particular devices as they define an internal storage in the contract, but they dos not use a flasher image and instead rely on the bootloader's exposing the internal storage.

However, resin-init-flasher has a built time check for all devices that define internal storage to define INTERNAL_DEVICE_KERNEL, so the build fails when initramfs-framework builds the resin-init-flasher dependency.

The lack of a `jq` dependency on earlier versions of meta-balena meant that the check was non-operative, but it started failing when the dependency was added.

This commit removes the migrator module from being built and included in the initramfs.

Relates-to: https://github.com/balena-os/meta-balena/pull/3317

Changelog-entry: remove migrator module for revpi family