### PR TITLE
conf: machine: revpi4: move SOC_MACHINE so it sets correctly

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/machine/include/revpi4.inc
+++ b/layers/meta-balena-raspberrypi/conf/machine/include/revpi4.inc
@@ -1,11 +1,11 @@
 MACHINEOVERRIDES = "raspberrypi4-64:${MACHINE}"
 include conf/machine/raspberrypi4-64.conf
 
+SOC_FAMILY = "rpi:revpi"
+
 # because we override the raspberrypi4-64 machine which in turn is an override of raspberrypi4, we need to do the following gimmick:
 # courtesy of https://github.com/balena-os/balena-jetson/pull/112/commits/9d21df6899e595b4aeab4cc9a939ae6c564c669a
 MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':raspberrypi4-64:${MACHINE}')}"
-
-SOC_FAMILY = "rpi:revpi"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-kunbus"
 


### PR DESCRIPTION
Move the SOC_MACHINE setting before the MACHINEOVERRIDES immediate assignment so it gets taken into account when setting MACHINEOVERRIDES.

Otherwise the `revpi` machine override gets lost.

Changelog-entry: apply revpi machine override for revpi4 family