### PR TITLE
systemd-shutdown: adjust watchdog expiration time

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/systemd/systemd/rpi/watchdog.conf
+++ b/layers/meta-balena-raspberrypi/recipes-core/systemd/systemd/rpi/watchdog.conf
@@ -1,0 +1,3 @@
+[Manager]
+RuntimeWatchdogSec=10s
+RebootWatchdogSec=15s


### PR DESCRIPTION
By default, the second stage watchdog time that is used to set the watchdog once systemd-shutdown has stopped all services and replaced PID1 with itself is set to 10m.

However, the RPI watchdog has a maximum timeout of 15s, so we adjust this value accordingly.

This helps ensure that when a shutdown or reboot is triggered, the device can fallback to a watchdog reboot if it gets stuck.

Changelog-entry: adjust reboot watchdog timeout