### PR TITLE
systemd: configure panic on hung tasks and extend timeout

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/systemd/systemd/rpi/balena-os-sysctl.conf
+++ b/layers/meta-balena-raspberrypi/recipes-core/systemd/systemd/rpi/balena-os-sysctl.conf
@@ -1,0 +1,8 @@
+fs.inotify.max_user_instances=512
+net.ipv4.ip_local_port_range=49152 65535
+vm.overcommit_memory=1
+net.ipv4.conf.all.rp_filter=2
+kernel.printk = 4 4 1 7
+kernel.hung_task_panic = 1
+kernel.hung_task_timeout_secs = 240
+

--- a/layers/meta-balena-raspberrypi/recipes-core/systemd/systemd_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend:rpi := "${THISDIR}/${PN}/rpi:"


### PR DESCRIPTION
On long run reboot tests we have seen devices get stuck on reboot when systemd-shutdown hangs and systemd is still refreshing the hardware watchdog. Those devices are unreachable until power cycled.

To avoid this, we configure the devices to panic on hung task detection which will reboot the device. However, as we know the engine might hang itself when pulling big images, we also extend the timeout from 2m to 4m to try and avoid this.

Changelog-entry: configure panic on hung tasks and extend timeout