### PR TITLE
usbboot: update to match the EEPROM firware version

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-bsp/rpi-eeprom/rpi-eeprom_git.bb
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/rpi-eeprom/rpi-eeprom_git.bb
@@ -97,6 +97,7 @@ do_compile[depends] += " \
     python3-pycryptodomex-native:do_populate_sysroot \
     balena-keys:do_deploy \
 "
+do_compile[vardeps] = "SIGN_API"
 
 do_install() {
   install -d ${D}${libexecdir}

--- a/layers/meta-balena-raspberrypi/recipes-devtools/usbboot/usbboot-native_git.bb
+++ b/layers/meta-balena-raspberrypi/recipes-devtools/usbboot/usbboot-native_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/raspberrypi/usbboot"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
-SRCREV = "dce11e8d491051430d4ece572fea03448586a708"
+SRCREV = "dce7f60c78e16794c8a03ba1f0089fec1d23a873"
 SRC_URI = "git://github.com/raspberrypi/usbboot.git;protocol=https;branch=master"
 
 inherit sign-rsa pkgconfig deploy native


### PR DESCRIPTION
The rpi-eeprom recipe is using 3b393d31ac0f1864420d47028b5703a70ad8da8f.

This commit updates the usbboot recipe to build a version that includes the above EEPROM firmware.

Changelog-entry: update usbboot to match EEPROM firmware version