### PR TITLE
image-sign-rpi.bbclass: reorder tasks to avoid missing boot files

### DIFF
--- a/layers/meta-balena-raspberrypi/classes/image-sign-rpi.bbclass
+++ b/layers/meta-balena-raspberrypi/classes/image-sign-rpi.bbclass
@@ -124,4 +124,4 @@ do_balena_signed_bootgen_and_deploy[vardeps] += " \
     SIGN_RSA_KEY_ID \
     "
 
-addtask balena_signed_bootgen_and_deploy after do_resin_boot_dirgen_and_deploy  before do_image_complete
+addtask balena_signed_bootgen_and_deploy after do_resin_boot_dirgen_and_deploy  before do_image_balenaos_img


### PR DESCRIPTION
At this moment `do_balena_signed_bootgen_and_deploy` and `do_image_balenaos_img` tasks run in parallel, which is causing problems as `do_image_balenaos_img` needs to use the output of `do_balena_signed_bootgen_and_deploy` to generate the contents of the boot partition. Since the call to the signing server takes several seconds, sometimes `boot.sig` or `boot.img` or both are not included in the final image, depending on when `do_image_balenaos_img` is actually executed.

This patch reorders the tasks so that `do_image_balenaos_img` is only started after `do_balena_signed_bootgen_and_deploy`.
