### PR TITLE
linux-kunbus_6.1.46.bb: Fix SRC_URI

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus_6.1.46.bb
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus_6.1.46.bb
@@ -4,9 +4,8 @@ LINUX_VERSION = "6.1.46"
 
 SRCREV = "raspberrypi-kernel_1%9.20240205+1-6.1.46-1-revpi11+1"
 SRC_URI = " \
-	git://gitlab.com/revolutionpi/linux;protocol=https;branch=revpi-6.1 \
+	git://github.com/RevolutionPi/linux;protocol=https;branch=revpi-6.1 \
 "
-
 require recipes-kernel/linux/linux-raspberrypi.inc
 
 SRC_URI:remove = "file://rpi-kernel-misc.cfg"


### PR DESCRIPTION
Builds recently started failing with the following error:

fatal: unable to access 'https://gitlab.com/revolutionpi/linux/': Failed to connect to gitlab.com port 443: No route to host

Changelog-entry: Fix SRC_URI format for linux-kunbus_6.1.46