### PR TITLE
u-boot: Correct patches' Upstream-Status

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-avoid-block-uart-write.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-avoid-block-uart-write.patch
@@ -9,7 +9,7 @@ thus preventing the board from booting.
 
 Let's add a retry count to unblock in such cases.
 
-Upstream-status: Inappropriate [configuration]
+Upstream-Status: Inappropriate [configuration]
 Signed-off-by: Alexandru Costache <alexandru@balena.io>
 ---
  drivers/serial/serial_bcm283x_mu.c | 12 +++++++++---

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-rpi-Disable-image-flasher-check.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/0001-rpi-Disable-image-flasher-check.patch
@@ -10,7 +10,7 @@ executed without reason when booting
 from sd-card, IF "usb" is also present
 in resin_uboot_device_types array.
 
-Upstream-status: Inappropriate[configuration]
+Upstream-Status: Inappropriate [configuration]
 Signed-off-by: Alexandru Costache <alexandru@balena.io>
 ---
  include/configs/rpi.h | 3 ++-

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/Revert-remove-include-config_defaults.h.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/Revert-remove-include-config_defaults.h.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Revert "remove include/config_defaults.h"
 
 This reverts commit 5c6a4d5a2779d7c2611319076d9aa4a23981855f.
 
-Upstream-status: Inappropriate [configuration]
+Upstream-Status: Inappropriate [configuration]
 Signed-off-by: Alexandru Costache <alexandru@balena.io>
 ---
  include/config_defaults.h | 12 ++++++++++++

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/pi4-fix-crash-when-issuing-usb-reset.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/pi4-fix-crash-when-issuing-usb-reset.patch
@@ -13,7 +13,7 @@ u-boot won't crash or reset.
 Rebased from last patch in this series:
 http://u-boot.10912.n7.nabble.com/RFC-PATCH-v2-0-5-Improve-USB-Keyboard-support-for-rpi3-rpi4-td418314.html#a418316
 
-Upstream-status: Pending
+Upstream-Status: Pending
 Signed-off-by: Alexandru Costache <alexandru@balena.io>
 ---
  drivers/usb/host/xhci-ring.c | 15 +++++++++++----

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/rpi4-include-configs-Use-config-defaults.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/rpi4-include-configs-Use-config-defaults.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] include/configs: Use config defaults
 Upstream does not include the config defaults
 as added by meta-balena. Let's include them.
 
-Upstream-status: Inappropriate[configuration]
+Upstream-Status: Inappropriate [configuration]
 Signed-off-by: Alexandru Costache <alexandru@balena.io>
 ---
  include/configs/rpi.h | 6 ++++++

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/serial_pl01x-Add-retry-limit-when-writing-to-uart-co.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/serial_pl01x-Add-retry-limit-when-writing-to-uart-co.patch
@@ -8,7 +8,7 @@ to the console if uart has been disabled or is incorrectly
 configured. Let's add a retry timeout and give up if impossible
 to put chars on the line, like we did for bcm283x_mu.
 
-Upstream-status: Inappropriate [configuration]
+Upstream-Status: Inappropriate [configuration]
 Signed-off-by: Alexandru Costache <alexandru@balena.io>
 ---
  drivers/serial/serial_pl01x.c | 11 +++++++++--

--- a/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/u-boot-Remove-usb-start-from-CONFIG_PREBOOT.patch
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/u-boot/u-boot/u-boot-Remove-usb-start-from-CONFIG_PREBOOT.patch
@@ -9,7 +9,7 @@ This config was removed from rpi.h and moved to the defconfigs,
 so we add it back for all PIs except for Pi4 and Pi400 where
 there were requests to boot from USB drives.
 
-Upstream-status: Inappropriate [configuration]
+Upstream-Status: Inappropriate [configuration]
 Signed-off-by: Alexandru Costache <alexandru@balena.io>
 ---
  configs/rpi_0_w_defconfig   | 2 +-


### PR DESCRIPTION
As indicated at https://docs.yoctoproject.org/contributor-guide/recipe-style-guide.html#patch-upstream-status

Changelog-entry: Correct the Upstream-Status of u-boot patches