### PR TITLE
Add custom overlay for SC16IS752 used in Industrial Shields RPI PLC

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0001-overlays-Add-overlay-for-RPI-PLC-SC16IS752.patch
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/0001-overlays-Add-overlay-for-RPI-PLC-SC16IS752.patch
@@ -1,0 +1,93 @@
+commit e5cf36f74f68f53e2b2f89669c0fb029cd810bab
+Author: RickyFA <rfa@industrialshields.com>
+Date:   Fri Nov 29 08:51:37 2024 +0100
+
+    [PATCH] overlays: Add custom overlay for SC16IS752 used in Industrial Shields RPI PLC
+    
+    Signed-off-by: Ricard Franch <rfa@industrialshields.com>
+
+diff --git a/arch/arm/boot/dts/overlays/sc16is752-spi1-rpiplc-v4-overlay.dts b/arch/arm/boot/dts/overlays/sc16is752-spi1-rpiplc-v4-overlay.dts
+new file mode 100644
+index 000000000..73be72925
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/sc16is752-spi1-rpiplc-v4-overlay.dts
+@@ -0,0 +1,79 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "brcm,bcm2835";
++
++	fragment@0 {
++		target = <&gpio>;
++		__overlay__ {
++			spi1_pins: spi1_pins {
++				brcm,pins = <19 20 21>;
++				brcm,function = <3>; /* alt4 */
++			};
++
++			spi1_cs_pins: spi1_cs_pins {
++				brcm,pins = <18 17>;
++				brcm,function = <1>; /* output */
++			};
++		};
++	};
++
++	fragment@1 {
++		target = <&spi1>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			pinctrl-names = "default";
++			pinctrl-0 = <&spi1_pins &spi1_cs_pins>;
++			cs-gpios = <&gpio 18 1>, <&gpio 17 1>;
++			status = "okay";
++
++			sc16is752_0: sc16is752@0 {
++				compatible = "nxp,sc16is752";
++				reg = <0>; /* CE0 */
++				clocks = <&sc16is752_clk>;
++				interrupt-parent = <&gpio>;
++				interrupts = <22 2>; /* IRQ_TYPE_EDGE_FALLING */
++				gpio-controller;
++				#gpio-cells = <2>;
++				spi-max-frequency = <4000000>;
++			};
++
++			sc16is752_1: sc16is752@1 {
++				compatible = "nxp,sc16is752";
++				reg = <1>; /* CE1 */
++				clocks = <&sc16is752_clk>;
++				interrupt-parent = <&gpio>;
++				interrupts = <16 2>; /* IRQ_TYPE_EDGE_FALLING */
++				gpio-controller;
++				#gpio-cells = <2>;
++				spi-max-frequency = <4000000>;
++			};
++		};
++	};
++
++	fragment@2 {
++		target = <&aux>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@3 {
++		target-path = "/";
++		__overlay__ {
++			sc16is752_clk: sc16is752_spi1_0_clk {
++				compatible = "fixed-clock";
++				#clock-cells = <0>;
++				clock-frequency = <14745600>;
++			};
++		};
++	};
++
++	__overrides__ {
++		int_pin_0 = <&sc16is752_0>,"interrupts:0";
++		int_pin_1 = <&sc16is752_1>,"interrupts:0";
++		xtal = <&sc16is752_clk>,"clock-frequency:0";
++	};
++};

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.15.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.15.bbappend
@@ -24,6 +24,7 @@ SRC_URI:append = " \
 	file://0011-USB-serial-Add-support-for-more-Quectel-modules.patch \
 	file://0001-waveshare-sim7600-Add-dtbo-for-this-modem.patch \
 	file://0001-overlays-Add-overlay-for-Seeed-reComputer-R1000.patch \
+	file://0001-overlays-Add-overlay-for-RPI-PLC-SC16IS752.patch \
 "
 
 SRC_URI:append:rt-rpi-300 = " \


### PR DESCRIPTION
This overlay is a modified version from https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm/boot/dts/overlays/sc16is752-spi1-overlay.dts