### PR TITLE
recipes-core/packagegroups: add linux-firmware-mt7601u back to all pi…

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -70,7 +70,6 @@ REMOVED_FOR_HUP_SPACE = " \
     linux-firmware-rpidistro-bcm43430 \
     linux-firmware-sd8887 \
     bluez-firmware-rpidistro-bcm43430a1-hcd \
-    linux-firmware-mt7601u \
 "
 
 # Temporary make space for HUP, untill firmwares


### PR DESCRIPTION
… device types

This firmware is used by a common  wifi dongle, often bundled with raspberrypi products: https://thepihut.com/products/usb-wifi-adapter-for-the-raspberry-pi

We should allow for it. Opening PR to see if rootfs can accommodate it

Changelog-entry:recipes-core/packagegroups: add linux-firmware-mt7601u back to all pi device types