### PR TITLE
Explicitely set the default CMA size

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -169,3 +169,5 @@ KERNEL_FEATURES:remove:revpi-core-3 = "cfg/fs/vfat.scc"
 KERNEL_FEATURES:remove:revpi-connect = "cfg/fs/vfat.scc"
 KERNEL_FEATURES:remove:revpi-connect-s = "cfg/fs/vfat.scc"
 KERNEL_FEATURES:remove:revpi-connect-4 = "cfg/fs/vfat.scc"
+
+VC4DTBO = "vc4-kms-v3d,cma-320"

--- a/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
+++ b/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
@@ -28,6 +28,7 @@ GPU_MEM = "16"
 DISABLE_VC4GRAPHICS = "1"
 DISABLE_VC4GRAPHICS:remove:raspberrypi3-64 = "1"
 DISABLE_VC4GRAPHICS:remove:raspberrypi4-64 = "1"
+DISABLE_VC4GRAPHICS:remove:raspberrypi5 = "1"
 DISABLE_VC4GRAPHICS:remove:raspberrypi0-2w-64 = "1"
 DISABLE_VC4GRAPHICS:remove:revpi-connect-s = "1"
 

--- a/layers/meta-balena-raspberrypi/recipes-support/hostapp-update-hooks/files/9999-bootfiles
+++ b/layers/meta-balena-raspberrypi/recipes-support/hostapp-update-hooks/files/9999-bootfiles
@@ -19,6 +19,9 @@ sed "/dtoverlay=i2c-rtc,pcf2127/d" /mnt/boot/config.txt > /mnt/boot/config.txt.n
 sed "/Enable RevPi specific pins for spi/d" /mnt/boot/config.txt > /mnt/boot/config.txt.new
 sed "s/dtoverlay=kunbus/dtoverlay=revpi-core/g" /mnt/boot/config.txt > /mnt/boot/config.txt.new
 
+info "Setting the CMA default size to 320M for backwards compatibility"
+sed '/dtoverlay=vc4-kms-v3d,cma-320/! s/dtoverlay=vc4-kms-v3d/dtoverlay=vc4-kms-v3d,cma-320/g' /mnt/boot/config.txt > /mnt/boot/config.txt.new
+
 sync -f /mnt/boot
 mv /mnt/boot/config.txt.new /mnt/boot/config.txt
 sync -f /mnt/boot


### PR DESCRIPTION
The default CMA size has been 320M until the 6.1.y kernel increased it to 512M in 9b523e1fc8a786da6fb6e0a8301d2fb4a2332dbb.

This breaks applications that were setting high `gpu_mem` values as the combination of CMA + GPU memory cannot exceed 32bit DMA accessible memory.

This commit explicitely sets 320M as default to keep backwards compatibility.

Change-type: patch