### PR TITLE
Add support for EDATEC CM4 Sensing

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/machine/raspberrypi4-edatec-sensing.conf
+++ b/layers/meta-balena-raspberrypi/conf/machine/raspberrypi4-edatec-sensing.conf
@@ -2,11 +2,5 @@
 #@NAME: EDATEC CM4 Sensing
 #@DESCRIPTION: Machine configuration for EDATEC CM4 Sensing Board
 
-MACHINEOVERRIDES = "raspberrypi4-64:${MACHINE}"
+MACHINEOVERRIDES =. "raspberrypi4-64:"
 include conf/machine/raspberrypi4-64.conf
-
-# because we override the raspberrypi4-64 machine which in turn is an override of raspberrypi4, we need to do the following gimmick:
-# courtesy of https://github.com/balena-os/balena-jetson/pull/112/commits/9d21df6899e595b4aeab4cc9a939ae6c564c669a
-MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':raspberrypi4-64:${MACHINE}')}"
-
-PREFERRED_VERSION_linux-raspberrypi = "6.%"

--- a/layers/meta-balena-raspberrypi/conf/machine/raspberrypi4-edatec-sensing.conf
+++ b/layers/meta-balena-raspberrypi/conf/machine/raspberrypi4-edatec-sensing.conf
@@ -1,0 +1,12 @@
+#@TYPE: Machine
+#@NAME: EDATEC CM4 Sensing
+#@DESCRIPTION: Machine configuration for EDATEC CM4 Sensing Board
+
+MACHINEOVERRIDES = "raspberrypi4-64:${MACHINE}"
+include conf/machine/raspberrypi4-64.conf
+
+# because we override the raspberrypi4-64 machine which in turn is an override of raspberrypi4, we need to do the following gimmick:
+# courtesy of https://github.com/balena-os/balena-jetson/pull/112/commits/9d21df6899e595b4aeab4cc9a939ae6c564c669a
+MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':raspberrypi4-64:${MACHINE}')}"
+
+PREFERRED_VERSION_linux-raspberrypi = "6.%"

--- a/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
+++ b/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
@@ -14,6 +14,7 @@
 #MACHINE ?= "rt-rpi-300"
 #MACHINE ?= "raspberrypi3-unipi-neuron"
 #MACHINE ?= "raspberrypi4-superhub"
+#MACHINE ?= "raspberrypi4-edatec-sensing"
 #MACHINE ?= "raspberrypi4-unipi-neuron"
 #MACHINE ?= "raspberrypi5"
 

--- a/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -93,6 +93,25 @@ EOF
     sed -i 's/enable_uart=1//' ${DEPLOYDIR}/bootfiles/config.txt
 }
 
+do_deploy:append:raspberrypi4-edatec-sensing() {
+	# Disable spi0
+	sed -i '/dtparam=spi=on/ c\dtparam=spi=off' ${DEPLOYDIR}/bootfiles/config.txt
+
+	# Use the dt overlays required by the raspberrypicm4 sensing boards
+	echo "dtparam=ant2" >> ${DEPLOYDIR}/bootfiles/config.txt
+	echo "dtparam=i2c_arm=on" >> ${DEPLOYDIR}/bootfiles/config.txt
+	echo "enable_uart=1" >> ${DEPLOYDIR}/bootfiles/config.txt
+	echo "otg_mode=1" >> ${DEPLOYDIR}/bootfiles/config.txt
+	echo "dtoverlay=ed-sdhost" >> ${DEPLOYDIR}/bootfiles/config.txt
+	echo "dtoverlay=i2c-rtc,pcf8563" >> ${DEPLOYDIR}/bootfiles/config.txt
+	echo "dtoverlay=spi6-1cs,cs0_pin=18,cs0_spidev=disabled" >> ${DEPLOYDIR}/bootfiles/config.txt
+	echo "dtoverlay=ed-mcp2515,spi6-0,oscillator=16000000,interrupt=7" >> ${DEPLOYDIR}/bootfiles/config.txt
+	echo "dtoverlay=uart2" >> ${DEPLOYDIR}/bootfiles/config.txt
+	echo "dtoverlay=uart3" >> ${DEPLOYDIR}/bootfiles/config.txt
+	echo "dtoverlay=uart4" >> ${DEPLOYDIR}/bootfiles/config.txt
+	echo "dtoverlay=uart5" >> ${DEPLOYDIR}/bootfiles/config.txt
+}
+
 # On Raspberry Pi 3 and Raspberry Pi Zero WiFi, serial ttyS0 console is only
 # usable if ENABLE_UART = 1. On OS development images, we want serial console
 # available, production devices can enable it with a configuration variable.

--- a/layers/meta-balena-raspberrypi/recipes-core/extra-udev-rules/extra-udev-rules.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/extra-udev-rules/extra-udev-rules.bbappend
@@ -6,6 +6,10 @@ SRC_URI:append = " \
 	file://revpi_mac \
 	"
 
+SRC_URI:append:raspberrypi4-edatec-sensing = " \
+	file://98-com-sensing.rules \
+	"
+
 do_install:append:fincm3() {
 	# Install balenaFin uAP interface rules
 	install -D -m 0644 ${WORKDIR}/86-nm-unmanaged-fin.rules ${D}/lib/udev/rules.d/86-nm-unmanaged-fin.rules
@@ -15,6 +19,11 @@ do_install:append:revpi() {
 	# Install RevPi specific rules
 	install -D -m 0644 ${WORKDIR}/50-revpi.rules ${D}/lib/udev/rules.d/50-revpi.rules
 	install -D -m 0755 ${WORKDIR}/revpi_mac ${D}/lib/udev/revpi_mac
+}
+
+do_install:append:raspberrypi4-edatec-sensing() {
+    install -d ${D}${base_libdir}/udev/rules.d
+    install -m 0644 ${WORKDIR}/98-com-sensing.rules ${D}${base_libdir}/udev/rules.d/
 }
 
 RDEPENDS:${PN}:append:revpi = "bash"

--- a/layers/meta-balena-raspberrypi/recipes-core/extra-udev-rules/files/98-com-sensing.rules
+++ b/layers/meta-balena-raspberrypi/recipes-core/extra-udev-rules/files/98-com-sensing.rules
@@ -1,0 +1,8 @@
+# Used to generate uart aliases for EDATEC's CM4 Sensing.
+# Support: support@edatec.cn
+
+KERNEL=="serial0", SYMLINK+="rs232"
+KERNEL=="ttyAMA2", SYMLINK+="rs485-3"
+KERNEL=="ttyAMA3", SYMLINK+="rs485-1"
+KERNEL=="ttyAMA4", SYMLINK+="rs485-2"
+KERNEL=="ttyAMA5", SYMLINK+="rs485-4"

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/raspberrypi4-edatec-sensing/0001-Add-ed-mcp2515-overlay-and-ed-sdhost-overlay.patch
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi/raspberrypi4-edatec-sensing/0001-Add-ed-mcp2515-overlay-and-ed-sdhost-overlay.patch
@@ -1,0 +1,258 @@
+From f26c1ae136324ed3412a1a23e1c20ea3d21205a2 Mon Sep 17 00:00:00 2001
+From: RayX123456 <rxie@edatec.cn>
+Date: Wed, 19 Feb 2025 18:11:49 +0800
+Subject: [PATCH] Add ed-mcp2515-overlay and ed-sdhost-overlay
+
+---
+ arch/arm/boot/dts/overlays/Makefile           |   2 +
+ .../boot/dts/overlays/ed-mcp2515-overlay.dts  | 181 ++++++++++++++++++
+ .../boot/dts/overlays/ed-sdhost-overlay.dts   |  36 ++++
+ 3 files changed, 219 insertions(+)
+ create mode 100644 arch/arm/boot/dts/overlays/ed-mcp2515-overlay.dts
+ create mode 100644 arch/arm/boot/dts/overlays/ed-sdhost-overlay.dts
+
+diff --git a/arch/arm/boot/dts/overlays/Makefile b/arch/arm/boot/dts/overlays/Makefile
+index 98ee137b1250..cc5785e2854c 100644
+--- a/arch/arm/boot/dts/overlays/Makefile
++++ b/arch/arm/boot/dts/overlays/Makefile
+@@ -60,6 +60,8 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
+ 	draws.dtbo \
+ 	dwc-otg.dtbo \
+ 	dwc2.dtbo \
++	ed-mcp2515.dtbo \
++	ed-sdhost.dtbo \
+ 	edt-ft5406.dtbo \
+ 	enc28j60.dtbo \
+ 	enc28j60-spi2.dtbo \
+diff --git a/arch/arm/boot/dts/overlays/ed-mcp2515-overlay.dts b/arch/arm/boot/dts/overlays/ed-mcp2515-overlay.dts
+new file mode 100644
+index 000000000000..b5f38e824166
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/ed-mcp2515-overlay.dts
+@@ -0,0 +1,181 @@
++// SPDX-License-Identifier: (GPL-2.0 OR MIT)
++
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/interrupt-controller/irq.h>
++#include <dt-bindings/pinctrl/bcm2835.h>
++
++/ {
++	compatible = "brcm,bcm2835";
++
++	fragment@0 {
++		target = <&spidev0>;
++		__dormant__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@1 {
++		target = <&spidev1>;
++		__dormant__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@2 {
++		target-path = "spi1/spidev@0";
++		__dormant__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@3 {
++		target-path = "spi1/spidev@1";
++		__dormant__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@4 {
++		target-path = "spi1/spidev@2";
++		__dormant__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@5 {
++		target-path = "spi2/spidev@0";
++		__dormant__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@6 {
++		target-path = "spi2/spidev@1";
++		__dormant__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@7 {
++		target-path = "spi2/spidev@2";
++		__dormant__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@8 {
++		target = <&gpio>;
++		__overlay__ {
++			mcp2515_pins: mcp2515_pins {
++				brcm,pins = <25>;
++				brcm,function = <BCM2835_FSEL_GPIO_IN>;
++			};
++		};
++	};
++
++	fragment@9 {
++		target-path = "/clocks";
++		__overlay__ {
++			clk_mcp2515_osc: mcp2515-osc {
++				#clock-cells = <0>;
++				compatible = "fixed-clock";
++				clock-frequency = <16000000>;
++			};
++		};
++	};
++
++	fragment@10 {
++		target-path = "spi6/spidev@0";
++		__dormant__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@11 {
++		target-path = "spi6/spidev@1";
++		__dormant__ {
++			status = "disabled";
++		};
++	};
++
++	mcp2515_frag: fragment@12 {
++		target = <&spi0>;
++		__overlay__ {
++			status = "okay";
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mcp2515: mcp2515@0 {
++				compatible = "microchip,mcp2515";
++				reg = <0>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&mcp2515_pins>;
++				spi-max-frequency = <10000000>;
++				interrupt-parent = <&gpio>;
++				interrupts = <25 IRQ_TYPE_LEVEL_LOW>;
++				clocks = <&clk_mcp2515_osc>;
++			};
++		};
++	};
++
++	__overrides__ {
++		spi0-0 = <0>, "+0",
++			<&mcp2515_frag>, "target:0=", <&spi0>,
++			<&mcp2515>, "reg:0=0",
++			<&mcp2515_pins>, "name=mcp2515_spi0_0_pins",
++			<&clk_mcp2515_osc>, "name=mcp2515-spi0-0-osc";
++		spi0-1 = <0>, "+1",
++			<&mcp2515_frag>, "target:0=", <&spi0>,
++			<&mcp2515>, "reg:0=1",
++			<&mcp2515_pins>, "name=mcp2515_spi0_1_pins",
++			<&clk_mcp2515_osc>, "name=mcp2515-spi0-1-osc";
++		spi1-0 = <0>, "+2",
++			<&mcp2515_frag>, "target:0=", <&spi1>,
++			<&mcp2515>, "reg:0=0",
++			<&mcp2515_pins>, "name=mcp2515_spi1_0_pins",
++			<&clk_mcp2515_osc>, "name=mcp2515-spi1-0-osc";
++		spi1-1 = <0>, "+3",
++			<&mcp2515_frag>, "target:0=", <&spi1>,
++			<&mcp2515>, "reg:0=1",
++			<&mcp2515_pins>, "name=mcp2515_spi1_1_pins",
++			<&clk_mcp2515_osc>, "name=mcp2515-spi1-1-osc";
++		spi1-2 = <0>, "+4",
++			<&mcp2515_frag>, "target:0=", <&spi1>,
++			<&mcp2515>, "reg:0=2",
++			<&mcp2515_pins>, "name=mcp2515_spi1_2_pins",
++			<&clk_mcp2515_osc>, "name=mcp2515-spi1-2-osc";
++		spi2-0 = <0>, "+5",
++			<&mcp2515_frag>, "target:0=", <&spi2>,
++			<&mcp2515>, "reg:0=0",
++			<&mcp2515_pins>, "name=mcp2515_spi2_0_pins",
++			<&clk_mcp2515_osc>, "name=mcp2515-spi2-0-osc";
++		spi2-1 = <0>, "+6",
++			<&mcp2515_frag>, "target:0=", <&spi2>,
++			<&mcp2515>, "reg:0=1",
++			<&mcp2515_pins>, "name=mcp2515_spi2_1_pins",
++			<&clk_mcp2515_osc>, "name=mcp2515-spi2-1-osc";
++		spi2-2 = <0>, "+7",
++			<&mcp2515_frag>, "target:0=", <&spi2>,
++			<&mcp2515>, "reg:0=2",
++			<&mcp2515_pins>, "name=mcp2515_spi2_2_pins",
++			<&clk_mcp2515_osc>, "name=mcp2515-spi2-2-osc";
++		spi6-0 = <0>, "+10",
++			<&mcp2515_frag>, "target:0=", <&spi6>,
++			<&mcp2515>, "reg:0=0",
++			<&mcp2515_pins>, "name=mcp2515_spi6_0_pins",
++			<&clk_mcp2515_osc>, "name=mcp2515-spi6-0-osc";
++		spi6-1 = <0>, "+11",
++			<&mcp2515_frag>, "target:0=", <&spi6>,
++			<&mcp2515>, "reg:0=1",
++			<&mcp2515_pins>, "name=mcp2515_spi6_1_pins",
++			<&clk_mcp2515_osc>, "name=mcp2515-spi6-1-osc";
++		oscillator = <&clk_mcp2515_osc>, "clock-frequency:0";
++		speed = <&mcp2515>, "spi-max-frequency:0";
++		interrupt = <&mcp2515_pins>, "brcm,pins:0",
++			<&mcp2515>, "interrupts:0";
++	};
++};
++
+diff --git a/arch/arm/boot/dts/overlays/ed-sdhost-overlay.dts b/arch/arm/boot/dts/overlays/ed-sdhost-overlay.dts
+new file mode 100644
+index 000000000000..2b1ba6eb57f1
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/ed-sdhost-overlay.dts
+@@ -0,0 +1,36 @@
++/dts-v1/;
++/plugin/;
++
++/{
++	compatible = "brcm,bcm2711";
++
++	fragment@0 {
++		target = <&sdhost>;
++		frag0: __overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&sdio_gpio_22_27>;
++            bus-width = <4>;
++			brcm,overclock-50 = <0>;
++			brcm,pio-limit = <1>;
++			status = "okay";
++		};
++	};
++
++	fragment@1 {
++		target = <&gpio>;
++		__overlay__ {
++			sdio_gpio_22_27: sdio_gpio_22_27 {
++				brcm,pins = <22 23 24 25 26 27>;
++				brcm,function = <4>; /* BCM2835_FSEL_ALT0, SD0 */
++				brcm,pull = <0 2 2 2 2 2>;
++			};
++		};
++	};
++
++	__overrides__ {
++		overclock_50     = <&frag0>,"brcm,overclock-50:0";
++		force_pio        = <&frag0>,"brcm,force-pio?";
++		pio_limit        = <&frag0>,"brcm,pio-limit:0";
++		debug            = <&frag0>,"brcm,debug?";
++	};
++};
+-- 
+2.34.1
+

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_6.1%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_6.1%.bbappend
@@ -7,6 +7,10 @@ SRC_URI:append:raspberrypi4-superhub = " \
 	file://0004-Add-SD-host-DT-overlay-for-Phoenix-Board.patch \
 "
 
+SRC_URI:append:raspberrypi4-edatec-sensing = " \
+	file://0001-Add-ed-mcp2515-overlay-and-ed-sdhost-overlay.patch \
+"
+
 SRC_URI:append = " \
 	file://0002-wireless-wext-Bring-back-ndo_do_ioctl-fallback.patch \
 	file://0001-Add-npe-x500-m3-overlay.patch \

--- a/raspberrypi4-edatec-sensing.coffee
+++ b/raspberrypi4-edatec-sensing.coffee
@@ -1,0 +1,33 @@
+deviceTypesCommon = require '@resin.io/device-types/common'
+{ networkOptions, commonImg, instructions } = deviceTypesCommon
+
+module.exports =
+	version: 1
+	slug: 'raspberrypi4-edatec-sensing'
+	name: 'EDATEC CM4 Sensing'
+	arch: 'aarch64'
+	state: 'new'
+
+	instructions: commonImg.instructions
+	gettingStartedLink:
+		windows: 'https://www.balena.io/docs/learn/getting-started/raspberrypi4/nodejs/'
+		osx: 'https://www.balena.io/docs/learn/getting-started/raspberrypi4/nodejs/'
+		linux: 'https://www.balena.io/docs/learn/getting-started/raspberrypi4/nodejs/'
+
+	options: [ networkOptions.group ]
+
+	yocto:
+		machine: 'raspberrypi4-edatec-sensing'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
+		version: 'yocto-kirkstone'
+		deployArtifact: 'balena-image-raspberrypi4-edatec-sensing.balenaos-img'
+		compressed: true
+
+	configuration:
+		config:
+			partition:
+				primary: 1
+			path: '/config.json'
+
+	initialization: commonImg.initialization


### PR DESCRIPTION
Add support for EDATEC CM4 Sensing

Add CM4Sensing kernel patch, add CM4 Sensing layer based on raspberrypi4. Add udev rules and configure config.txt for CM4 Sensing.

Changelog-entry: Add support for EDATEC CM4 Sensing
Signed-off-by: Ray <rxie@edatec.cn>