### PR TITLE
pi-bluetooth_%.bbappend: Use nonarch_base_libdir variable

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-connectivity/pi-bluetooth/pi-bluetooth_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-connectivity/pi-bluetooth/pi-bluetooth_%.bbappend
@@ -12,8 +12,8 @@ SRC_URI:append = " \
 
 do_install:append () {
     # Move udev rules into /lib as /etc/udev/rules.d is bind mounted for custom rules
-    install -d ${D}${base_libdir}/udev/rules.d
-    mv ${D}/etc/udev/rules.d/*.rules ${D}${base_libdir}/udev/rules.d/
+    install -d ${D}${nonarch_base_libdir}/udev/rules.d
+    mv ${D}/etc/udev/rules.d/*.rules ${D}${nonarch_base_libdir}/udev/rules.d/
 }
 
-FILES:${PN} += "/lib/udev/rules.d"
+FILES:${PN} += "${nonarch_base_libdir}/udev/rules.d"


### PR DESCRIPTION
Using the nonarch_base_libdir variable instead of hardcoding directly the path will help us when we enable the usrmerge feature.

Changelog-entry: Use nonarch_base_libdir variable when packaging files for pi-bluetooth recipe