### PR TITLE
linux-raspberrypi: enable CONFIG_MEMCG_V1

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -49,3 +49,8 @@ BALENA_CONFIGS[pieeprom] = " \
 
 BALENA_CONFIGS:append:raspberrypicm4-ioboard-sb = " dwc2"
 BALENA_CONFIGS[dwc2] = "CONFIG_USB_DWC2=y"
+
+BALENA_CONFIGS:append = " ${@configure_from_version("6.11", " memcg", "", d)}"
+BALENA_CONFIGS[memcg] = " \
+    CONFIG_MEMCG_V1=y \
+"


### PR DESCRIPTION
By updating the kernel to 6.12 we bumped the memory cgroup to v2 and v1 has to be explicitly selected, otherwise it gets compiled out. This is a problem as the rest of balenaOS runs on cgroups v1.

This patch enables memory cgroup v1.