### PR TITLE
linux-firmware-rpidistro_git: Update to version 20230625-2+rpt3

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
+++ b/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample
@@ -102,3 +102,5 @@ BB_DISKMON_DIRS = "\
 CONF_VERSION = "2"
 
 HOSTTOOLS += "docker iptables"
+
+LICENSE_FLAGS_ACCEPTED = "synaptics-killswitch"

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro/0001-Default-43455-firmware-to-standard-variant.patch
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro/0001-Default-43455-firmware-to-standard-variant.patch
@@ -1,0 +1,28 @@
+From b9db43e36ad0942d33cb4db5b394abd722862568 Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei.gherzan@huawei.com>
+Date: Fri, 9 Sep 2022 20:28:06 +0200
+Subject: [PATCH] Default 43455 firmware to standard variant
+
+The firmware for 43455 is loaded as a symlink: brcmfmac43455-sdio.bin.
+This symlink is now broken as the debian package handles the right
+target of this symlink through a postinstall. We don't have that logic
+here so we default to the standard variant.
+
+Upstream-Status: Inappropriate [issue reported at https://github.com/RPi-Distro/firmware-nonfree/issues/26]
+Signed-off-by: Andrei Gherzan <andrei.gherzan@huawei.com>
+---
+ debian/config/brcm80211/brcm/brcmfmac43455-sdio.bin | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.bin b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.bin
+index 9c39208..b914838 120000
+--- a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.bin
++++ b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.bin
+@@ -1 +1 @@
+-../cypress/cyfmac43455-sdio.bin
+\ No newline at end of file
++../cypress/cyfmac43455-sdio-standard.bin
+\ No newline at end of file
+-- 
+2.25.1
+

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
@@ -1,0 +1,118 @@
+SUMMARY = "Linux kernel firmware files from Raspbian distribution"
+DESCRIPTION = "Updated firmware files for RaspberryPi hardware. \
+RPi-Distro obtains these directly from Cypress; they are not submitted \
+to linux-firmware for general use."
+HOMEPAGE = "https://github.com/RPi-Distro/firmware-nonfree"
+SECTION = "kernel"
+
+LICENSE = "GPL-2.0-only & binary-redist-Cypress-rpidistro & Synaptics-rpidistro"
+LIC_FILES_CHKSUM = "\
+    file://debian/copyright;md5=291ee5385b4cf74b10c5fb5a46a7bbc6 \
+"
+# Where these are no common licenses, set NO_GENERIC_LICENSE so that the
+# license files will be copied from the fetched source.
+NO_GENERIC_LICENSE[binary-redist-Cypress-rpidistro] = "debian/copyright"
+NO_GENERIC_LICENSE[Synaptics-rpidistro] = "debian/copyright"
+LICENSE_FLAGS = "synaptics-killswitch"
+
+SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree;branch=bookworm;protocol=https \
+    file://0001-Default-43455-firmware-to-standard-variant.patch \
+"
+SRCREV = "4b356e134e8333d073bd3802d767a825adec3807"
+PV = "20230625-2+rpt3"
+S = "${WORKDIR}/git"
+
+inherit allarch
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+# The minimal firmware doesn't work with Raspberry Pi 5, so default to the
+# standard firmware
+CYFMAC43455_SDIO_FIRMWARE ??= "minimal"
+CYFMAC43455_SDIO_FIRMWARE:raspberrypi5 ??= "standard"
+
+do_install() {
+    install -d ${D}${nonarch_base_libdir}/firmware/brcm ${D}${nonarch_base_libdir}/firmware/cypress
+
+    cp debian/copyright ${D}${nonarch_base_libdir}/firmware/copyright.firmware-nonfree-rpidistro
+
+    for fw in \
+            brcmfmac43430-sdio \
+            brcmfmac43430b0-sdio \
+            brcmfmac43436-sdio \
+            brcmfmac43436s-sdio \
+            brcmfmac43455-sdio \
+            brcmfmac43456-sdio; do
+        cp -R --no-dereference --preserve=mode,links -v debian/config/brcm80211/brcm/${fw}.* ${D}${nonarch_base_libdir}/firmware/brcm/
+    done
+
+    cp -R --no-dereference --preserve=mode,links -v debian/config/brcm80211/cypress/* ${D}${nonarch_base_libdir}/firmware/cypress/
+    ln -s cyfmac43455-sdio-${CYFMAC43455_SDIO_FIRMWARE}.bin ${D}${nonarch_base_libdir}/firmware/cypress/cyfmac43455-sdio.bin
+
+    rm ${D}${nonarch_base_libdir}/firmware/cypress/README.txt
+}
+
+PACKAGES = "\
+    ${PN}-bcm43430 \
+    ${PN}-bcm43436 \
+    ${PN}-bcm43436s \
+    ${PN}-bcm43439 \
+    ${PN}-bcm43455 \
+    ${PN}-bcm43456 \
+    ${PN}-license \
+"
+
+LICENSE:${PN}-bcm43430 = "binary-redist-Cypress-rpidistro"
+LICENSE:${PN}-bcm43436 = "Synaptics-rpidistro"
+LICENSE:${PN}-bcm43436s = "Synaptics-rpidistro"
+LICENSE:${PN}-bcm43439 = "Synaptics-rpidistro"
+LICENSE:${PN}-bcm43455 = "binary-redist-Cypress-rpidistro"
+LICENSE:${PN}-bcm43456 = "Synaptics-rpidistro"
+LICENSE:${PN}-license = "GPL-2.0-only"
+
+FILES:${PN}-bcm43430 = " \
+    ${nonarch_base_libdir}/firmware/brcm/brcmfmac43430* \
+    ${nonarch_base_libdir}/firmware/cypress/cyfmac43430-sdio.bin \
+    ${nonarch_base_libdir}/firmware/cypress/cyfmac43430-sdio.clm_blob \
+"
+FILES:${PN}-bcm43436 = " \
+    ${nonarch_base_libdir}/firmware/brcm/brcmfmac43436-* \
+    ${nonarch_base_libdir}/firmware/brcm/brcmfmac43430b0-* \
+"
+FILES:${PN}-bcm43436s = "${nonarch_base_libdir}/firmware/brcm/brcmfmac43436s*"
+FILES:${PN}-bcm43439 = " \
+    ${nonarch_base_libdir}/firmware/cypress/43439A0-7.95.49.00.combined \
+    ${nonarch_base_libdir}/firmware/cypress/cyfmac43439-sdio* \
+"
+FILES:${PN}-bcm43455 = " \
+    ${nonarch_base_libdir}/firmware/brcm/brcmfmac43455* \
+    ${nonarch_base_libdir}/firmware/cypress/cyfmac43455-sdio* \
+"
+FILES:${PN}-bcm43456 = "${nonarch_base_libdir}/firmware/brcm/brcmfmac43456*"
+FILES:${PN}-license = "${nonarch_base_libdir}/firmware/copyright.firmware-nonfree-rpidistro"
+
+RDEPENDS:${PN}-bcm43430 += "${PN}-license"
+RDEPENDS:${PN}-bcm43436 += "${PN}-license"
+RDEPENDS:${PN}-bcm43436s += "${PN}-license"
+RDEPENDS:${PN}-bcm43439 += "${PN}-license"
+RDEPENDS:${PN}-bcm43455 += "${PN}-license"
+RDEPENDS:${PN}-bcm43456 += "${PN}-license"
+
+RCONFLICTS:${PN}-bcm43430 = "linux-firmware-raspbian-bcm43430"
+RCONFLICTS:${PN}-bcm43436 = "linux-firmware-bcm43436"
+RCONFLICTS:${PN}-bcm43436s = "linux-firmware-bcm43436s"
+RCONFLICTS:${PN}-bcm43439 = "linux-firmware-bcm43439"
+RCONFLICTS:${PN}-bcm43455 = "linux-firmware-bcm43455"
+RCONFLICTS:${PN}-bcm43456 = "linux-firmware-bcm43456"
+
+RREPLACES:${PN}-bcm43430 = "linux-firmware-bcm43430"
+RREPLACES:${PN}-bcm43436 = "linux-firmware-bcm43436"
+RREPLACES:${PN}-bcm43436s = "linux-firmware-bcm43436s"
+RREPLACES:${PN}-bcm43439 = "linux-firmware-bcm43439"
+RREPLACES:${PN}-bcm43455 = "linux-firmware-bcm43455"
+RREPLACES:${PN}-bcm43456 = "linux-firmware-bcm43456"
+
+# Firmware files are generally not run on the CPU, so they can be
+# allarch despite being architecture specific
+INSANE_SKIP = "arch"


### PR DESCRIPTION
This update brings in additional WiFi firmware for various RPi models.

This is taken from meta-raspberrypi master branch at revision cd558f77b6b1a6d0fa15cd9558df0c0262d42c91

Also, this also needs a local.conf change to accept the synaptics-killswitch license but as per https://github.com/RPi-Distro/firmware-nonfree/issues/29#issuecomment-1795717241 it should be fine.

Changelog-entry: Update linux-firmware-rpidistro to version 20230625-2+rpt3 for newer wifi firmware