### PR TITLE
recipes-core/packagegroup-balena-coonnectivity: add mt7612u firmware

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -2,6 +2,7 @@ CONNECTIVITY_FIRMWARES:append = " \
     linux-firmware-rpidistro-bcm43430 \
     linux-firmware-rpidistro-bcm43455 \
     linux-firmware-sd8887 \
+    linux-firmware-mt7612u \
     bluez-firmware-rpidistro-bcm43430a1-hcd \
     bluez-firmware-rpidistro-bcm4345c0-hcd \
 "


### PR DESCRIPTION
firmware for very common wifi dongles, sold on platforms vs pihut etc - customers often expect to work

Changelog-entry: recipes-core/packagegroup-balena-coonnectivity: add mt7612u firmware