### PR TITLE
linux-raspberrypi_%.bbappend: Enable the built-in rtl8192cu driver fo…

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -49,3 +49,8 @@ BALENA_CONFIGS[pieeprom] = " \
 
 BALENA_CONFIGS:append:raspberrypicm4-ioboard-sb = " dwc2"
 BALENA_CONFIGS[dwc2] = "CONFIG_USB_DWC2=y"
+
+BALENA_CONFIGS:append = " rtl8192"
+BALENA_CONFIGS[rtl8192] = " \
+    CONFIG_RTL8192CU=m \
+"

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.15.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_5.15.bbappend
@@ -73,10 +73,6 @@ BALENA_CONFIGS[pca955_gpio_expander] = " \
     CONFIG_GPIO_PCA953X=y \
     CONFIG_GPIO_PCA953X_IRQ=y \
     "
-BALENA_CONFIGS:append = " rtl8192"
-BALENA_CONFIGS[rtl8192] = " \
-    CONFIG_RTL8192CU=m \
-    "
 
 # requested by customer (support for Kontron PLD devices)
 BALENA_CONFIGS:append = " gpio_i2c_kempld"


### PR DESCRIPTION
…r all boards

The in-tree driver is stable now and should be used instead of the out-of-tree driver we had been using before. Let's enable it for all boards and not just for those using kernel version 5.15

Changelog-entry: Enable the built-in rtl8192cu driver for all boards