### PR TITLE
linux: Do not blacklist rtl8192cu

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus_%.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux-kunbus/linux-kunbus_%.bbappend
@@ -60,9 +60,6 @@ BALENA_CONFIGS[pca955_gpio_expander] = " \
     CONFIG_GPIO_PCA953X_IRQ=y \
     "
 
-KERNEL_MODULE_PROBECONF += "rtl8192cu"
-module_conf:rtl8192cu = "blacklist rtl8192cu"
-
 BALENA_CONFIGS:append = " ${@configure_from_version("6.1", "", " preempt_rt", d)}"
 BALENA_CONFIGS[preempt_rt] = " \
     CONFIG_PREEMPT_RT_FULL=y \

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_6.12.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_6.12.bbappend
@@ -64,9 +64,6 @@ BALENA_CONFIGS[pca955_gpio_expander] = " \
     CONFIG_GPIO_PCA953X_IRQ=y \
     "
 
-KERNEL_MODULE_PROBECONF += "rtl8192cu"
-module_conf_rtl8192cu = "blacklist rtl8192cu"
-
 # requested by customer (support for Kontron PLD devices)
 BALENA_CONFIGS:append = " gpio_i2c_kempld"
 BALENA_CONFIGS_DEPS[gpio_i2c_kempld] = " \


### PR DESCRIPTION
This driver is deemed stable now and we want to use it

Changelog-entry: Do not blacklist the rtl8192cu kernel driver