### PR TITLE
layer.conf: Use full version of cyfmac43455-sdio firmware

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -158,6 +158,9 @@ PREFERRED_VERSION_linux-raspberrypi:raspberrypi5 = "6.12%"
 # for the raspberrypi0-2w-64 we remain on 5.15 because of WiFi firmware related issues
 PREFERRED_VERSION_linux-raspberrypi:raspberrypi0-2w-64 = "5.15.%"
 
+# Use the full version of cyfmac43455-sdio firmware to support WPA3
+CYFMAC43455_SDIO_FIRMWARE = "standard"
+
 FIRMWARE_COMPRESSION:raspberrypi4-64 ?= "1"
 FIRMWARE_COMPRESSION:raspberrypi0-2w-64 ?= "1"
 


### PR DESCRIPTION
At this moment we're defaulting to the minimal variant of the cyfmac43455-sdio firmware on all devices except Pi5. We inherit this from upstream, who switched to minimal in Jan 2025.

This patch makes all the devices ship default to the full variant, which makes it possible to connect to WPA3 networks.