### PR TITLE
hailo-pci: Ship out-of-tree module after in-tree has been removed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,7 @@
 	path = layers/meta-balena-rpi-sb
 	url = https://github.com/balena-os/meta-balena-rpi-sb.git
 	branch = master
+[submodule "layers/meta-hailo"]
+	path = layers/meta-hailo
+	url = https://github.com/hailo-ai/meta-hailo.git
+	branch = hailo8-kirkstone

--- a/layers/meta-balena-raspberrypi/conf/samples/bblayers.conf.sample
+++ b/layers/meta-balena-raspberrypi/conf/samples/bblayers.conf.sample
@@ -19,4 +19,5 @@ BBLAYERS ?= " \
     ${TOPDIR}/../layers/meta-openembedded/meta-perl \
     ${TOPDIR}/../layers/meta-raspberrypi \
     ${TOPDIR}/../layers/meta-cyclonedx  \
+    ${TOPDIR}/../layers/meta-hailo/meta-hailo-accelerator \
     "

--- a/layers/meta-balena-raspberrypi/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/images/balena-image.bbappend
@@ -1,1 +1,3 @@
 include balena-image.inc
+
+IMAGE_INSTALL:append:raspberrypi5 = " hailo-pci"


### PR DESCRIPTION
Previous OS versions used to ship the in-tree hailo-pci kernel module for the Hailo chip on the official RPi AI HAT. This driver has been removed from the upstream kernel and now has to be built as out-of-tree.

We want to support the AI HAT, so we want to keep shipping the driver. Note that while the driver is GPLv2, the firmware has a custom EULA and we are not allowed to redistribute it.

Hailo provides a yocto layer that builds the driver, this patch adds the layer and makes the driver available on the Raspberry Pi 5.