### PR TITLE
layer.conf: Add missing hifiberry overlays

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/layer.conf
+++ b/layers/meta-balena-raspberrypi/conf/layer.conf
@@ -15,6 +15,19 @@ LAYERSERIES_COMPAT_balena-raspberrypi = "kirkstone"
 FULL_OPTIMIZATION:raspberrypi4-64 = "-Os -pipe ${DEBUG_FLAGS}"
 FULL_OPTIMIZATION:raspberrypi3-64 = "-Os -pipe ${DEBUG_FLAGS}"
 
+# Add hifiberry overlays that meta-raspberrypi doesn't include
+KERNEL_DEVICETREE:append = " \
+    overlays/hifiberry-adc.dtbo \
+    overlays/hifiberry-adc8x.dtbo \
+    overlays/hifiberry-amp4pro.dtbo \
+    overlays/hifiberry-dacplusadc.dtbo \
+    overlays/hifiberry-dacplus-pro.dtbo \
+    overlays/hifiberry-dacplus-std.dtbo \
+    overlays/hifiberry-dac8x.dtbo \
+    overlays/hifiberry-studio-dac8x.dtbo \
+    overlays/hifiberry-studio-dac8x-pro.dtbo \
+"
+
 KERNEL_DEVICETREE:append:fincm3 = " overlays/balena-fin.dtbo"
 KERNEL_DEVICETREE:append:fincm3 = " overlays/spyfly.dtbo"
 
@@ -102,9 +115,20 @@ KERNEL_DEVICETREE:remove:revpi = "overlays/audioinjector-isolated-soundcard.dtbo
     overlays/audiosense-pi.dtbo \
 "
 KERNEL_DEVICETREE:remove:revpi = "overlays/hdmi-backlight-hwhack-gpio.dtbo"
-KERNEL_DEVICETREE:remove:revpi = "overlays/hifiberry-amp100.dtbo"
-KERNEL_DEVICETREE:remove:revpi = "overlays/hifiberry-amp3.dtbo"
-KERNEL_DEVICETREE:remove:revpi = "overlays/hifiberry-dacplushd.dtbo"
+KERNEL_DEVICETREE:remove:revpi = " \
+    overlays/hifiberry-adc.dtbo \
+    overlays/hifiberry-adc8x.dtbo \
+    overlays/hifiberry-amp100.dtbo \
+    overlays/hifiberry-amp3.dtbo \
+    overlays/hifiberry-amp4pro.dtbo \
+    overlays/hifiberry-dacplusadc.dtbo \
+    overlays/hifiberry-dacplushd.dtbo \
+    overlays/hifiberry-dacplus-pro.dtbo \
+    overlays/hifiberry-dacplus-std.dtbo \
+    overlays/hifiberry-dac8x.dtbo \
+    overlays/hifiberry-studio-dac8x.dtbo \
+    overlays/hifiberry-studio-dac8x-pro.dtbo \
+"
 KERNEL_DEVICETREE:remove:revpi = "overlays/merus-amp.dtbo"
 KERNEL_DEVICETREE:remove:revpi = "overlays/overlay_map.dtb"
 KERNEL_DEVICETREE:remove:revpi = "overlays/2xmcp2517fd.dtbo"


### PR DESCRIPTION
Currently we only ship a subset of hifiberry overlays defined in meta-raspberrypi.

This patch appends the list to also include the missing ones that are shipped in upstream RaspiOS.