### PR TITLE
packagegroup-connectivity: remove TI Wilink firmware

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/images/balena-image-initramfs.bbappend
@@ -1,5 +1,7 @@
 PACKAGE_INSTALL:remove:revpi = "initramfs-module-migrate"
 
+PACKAGE_INSTALL:remove = "initramfs-module-recovery"
+
 # increase initramfs maxsize to 40 MiB
 IMAGE_ROOTFS_MAXSIZE:raspberrypi5 = "40960"
 IMAGE_ROOTFS_MAXSIZE:raspberrypi4-64 = "40960"

--- a/layers/meta-balena-raspberrypi/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -30,6 +30,11 @@ CONNECTIVITY_FIRMWARES:remove:raspberrypi0-2w-64 = " \
     bluez-firmware-rpidistro-bcm4345c0-hcd \
 "
 
+CONNECTIVITY_FIRMWARES:remove = " \
+    linux-firmware-wl12xx \
+    linux-firmware-wl18xx \
+"
+
 REMOVED_FOR_HUP_SPACE = " \
     linux-firmware-bcm43455 \
     linux-firmware-ibt-11-5 \
@@ -66,7 +71,6 @@ REMOVED_FOR_HUP_SPACE = " \
     linux-firmware-iwlwifi-7265d \
     linux-firmware-iwlwifi-8000c \
     linux-firmware-iwlwifi-8265 \
-    linux-firmware-wl18xx \
     linux-firmware-sd8887 \
 "
 


### PR DESCRIPTION
No RPi board has it, and no kernel in this layer builds the drivers that would load it (CONFIG_WLCORE, CONFIG_WL12XX and CONFIG_WL18XX are unset on both linux-raspberrypi 6.12 and 5.15).

Changelog-entry: remove TI Wilink firmware