### PR TITLE
linux-raspberrypi: enable kernel configs for Exein lite runtime on rp…

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_6.12.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_6.12.bbappend
@@ -179,14 +179,14 @@ BALENA_CONFIGS[iio_pressure_drivers] = " \
     CONFIG_BMP280=m \
 "
 
-# Enable the kernel interfaces required by the Exein "lite" runtime
-# on the 32-bit Raspberry Pi 3. fanotify (with access-permission decisions)
-# provides filesystem monitoring, and the netlink connector's process-event
-# reporting feeds process tracking.
-# Note: CONFIG_PROC_EVENTS depends on CONNECTOR=y (built-in), so CONNECTOR is
-# promoted from its default =m to =y here. FANOTIFY's and CONNECTOR's own
-# prerequisites (FSNOTIFY, NET) are already =y in the base defconfig.
+# Enable the kernel interfaces required by the Exein "lite" runtime.
+# fanotify (with access-permission decisions) provides filesystem monitoring,
+# and the netlink connector's process-event reporting feeds process tracking.
+# Note: CONFIG_PROC_EVENTS depends on CONNECTOR=y, so CONNECTOR has to be
+# built in rather than a module. FANOTIFY's and CONNECTOR's own prerequisites
+# (FSNOTIFY, NET) are already =y in the bcm2709/bcm2711 defconfigs.
 BALENA_CONFIGS:append:raspberrypi3 = " exein-lite"
+BALENA_CONFIGS:append:raspberrypi4-64 = " exein-lite"
 BALENA_CONFIGS[exein-lite] = " \
     CONFIG_FANOTIFY=y \
     CONFIG_FANOTIFY_ACCESS_PERMISSIONS=y \


### PR DESCRIPTION
…i4-64

Hopefully there is enough space to allow these small modules in the rootfs.

Changelog-entry: Enable kernel configs for Exein lite runtime on Raspberry Pi 4 (64-bit)