### PR TITLE
linux-raspberrypi: update to v6.12.107

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_6.12.inc
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_6.12.inc
@@ -3,22 +3,22 @@
 #
 # 1. Find latest upstream merge at https://github.com/raspberrypi/linux/commits/rpi-6.12.y
 #    Update SRCREV_machine to the merge commit hash
-#    - SRCREV_machine = "a923c1dcd822385aaa82a4388c6a6ad92cbf9280"
+#    - SRCREV_machine = "3117a9a53364f80b409e2ebe63ddc3e3bd89ee0c"
 #
 # 2. Find the version bump commit a few commits before the merge
 #    Update LINUX_VERSION to match the SUBLEVEL in Makefile
-#    - LINUX_VERSION = "6.12.94"
+#    - LINUX_VERSION = "6.12.107"
 #
 # 3. Find matching yocto-kernel-cache commit at https://git.yoctoproject.org/yocto-kernel-cache
 #    Look for "bump to 6.12.xx" commit on yocto-6.12 branch
 #    Update SRCREV_meta to that commit hash
-#    - SRCREV_meta = "01498af34f6fe82c08fa6eae50a7eff1904a3968"
+#    - SRCREV_meta = "4edcad3aff7de4c6702e6ac953bcf214ca9793dc"
 #
 # Note: Not all kernel versions have corresponding yocto-kernel-cache commits immediately
 
-LINUX_VERSION ?= "6.12.94"
+LINUX_VERSION ?= "6.12.107"
 LINUX_RPI_BRANCH ?= ""
 LINUX_RPI_KMETA_BRANCH ?= "yocto-6.12"
 
-SRCREV_machine = "a923c1dcd822385aaa82a4388c6a6ad92cbf9280"
-SRCREV_meta = "01498af34f6fe82c08fa6eae50a7eff1904a3968"
+SRCREV_machine = "3117a9a53364f80b409e2ebe63ddc3e3bd89ee0c"
+SRCREV_meta = "4edcad3aff7de4c6702e6ac953bcf214ca9793dc"


### PR DESCRIPTION
Update from v6.12.94 to v6.12.107, the current head of the stable rpi-6.12.y branch. SRCREV_meta tracks the latest available yocto-kernel-cache bump (v6.12.103) per the note in this file - no matching v6.12.107 kernel-cache commit exists yet.

Diffed the raspberrypi/linux tree between the old and new SRCREV_machine: only 5 files gained new Kconfig options anywhere in the tree (DRM buddy allocator + its kunit test, erofs LZMA stream tuning, a Rust toolchain internal, a new Airoha ethernet driver, and an m68k-only NR_CPUS option), none touching anything this repo's BALENA_CONFIGS/DT-overlay patches depend on.

Changelog-entry: update kernel to 6.12.107