### PR TITLE
Update unipi tooling to support kernel update

### DIFF
--- a/layers/meta-balena-raspberrypi/conf/machine/raspberrypi3-unipi-neuron.conf
+++ b/layers/meta-balena-raspberrypi/conf/machine/raspberrypi3-unipi-neuron.conf
@@ -5,4 +5,12 @@
 MACHINEOVERRIDES =. "raspberrypi3:"
 include conf/machine/raspberrypi3.conf
 
-IMAGE_INSTALL:append = " unipi-kernel-modules unipi-tools"
+IMAGE_INSTALL:append = " unipi-kernel-modules unipi-tools unipi-os-configurator unipi-os-configurator-data-neuron"
+
+# do_resin_boot_dirgen_and_deploy (meta-balena's image-balena.bbclass,
+# scheduled after do_rootfs, before do_image_complete/do_image_balenaos_img)
+# is what actually reads DEPLOY_DIR_IMAGE/bootfiles/overlays/ into the real
+# boot-partition workdir - depending on do_image_balenaos_img (a LATER task)
+# was too late: this recipe's do_deploy needs to finish before THIS task
+# runs, not merely before final image assembly.
+do_resin_boot_dirgen_and_deploy[depends] += "unipi-os-configurator-data-neuron:do_deploy"

--- a/layers/meta-balena-raspberrypi/conf/machine/raspberrypi4-unipi-neuron.conf
+++ b/layers/meta-balena-raspberrypi/conf/machine/raspberrypi4-unipi-neuron.conf
@@ -5,4 +5,12 @@
 MACHINEOVERRIDES =. "raspberrypi4-64:"
 include conf/machine/raspberrypi4-64.conf
 
-IMAGE_INSTALL:append = " unipi-kernel-modules unipi-tools"
+IMAGE_INSTALL:append = " unipi-kernel-modules unipi-tools unipi-os-configurator unipi-os-configurator-data-neuron"
+
+# do_resin_boot_dirgen_and_deploy (meta-balena's image-balena.bbclass,
+# scheduled after do_rootfs, before do_image_complete/do_image_balenaos_img)
+# is what actually reads DEPLOY_DIR_IMAGE/bootfiles/overlays/ into the real
+# boot-partition workdir - depending on do_image_balenaos_img (a LATER task)
+# was too late: this recipe's do_deploy needs to finish before THIS task
+# runs, not merely before final image assembly.
+do_resin_boot_dirgen_and_deploy[depends] += "unipi-os-configurator-data-neuron:do_deploy"

--- a/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -48,6 +48,10 @@ do_deploy:append:raspberrypi3-unipi-neuron() {
 	echo "dtoverlay=neuronee" >> ${DEPLOYDIR}/bootfiles/config.txt
 	echo "dtoverlay=i2c-rtc,mcp7941x" >> ${DEPLOYDIR}/bootfiles/config.txt
 	echo "dtoverlay=neuron-spi-new" >> ${DEPLOYDIR}/bootfiles/config.txt
+	# Declares the 24c01 ID EEPROM at i2c1@0x57 (unipi-os-configurator-data-neuron)
+	# so unipiid's udev rule fires, detects the attached model, and stages the
+	# matching per-model overlay/udev rules for os-configurator.
+	echo "dtoverlay=unipi_id" >> ${DEPLOYDIR}/bootfiles/config.txt
 }
 
 do_deploy:append:raspberrypi4-superhub() {
@@ -73,7 +77,21 @@ do_deploy:append:raspberrypi4-unipi-neuron() {
 	# Use the dt overlays required by the UniPi Neuron family of boards
 	echo "dtoverlay=neuronee" >> ${DEPLOYDIR}/bootfiles/config.txt
 	echo "dtoverlay=i2c-rtc,mcp7941x" >> ${DEPLOYDIR}/bootfiles/config.txt
-	echo "dtoverlay=neuron-spi-new" >> ${DEPLOYDIR}/bootfiles/config.txt
+	# Declares the 24c01 ID EEPROM at i2c1@0x57 (unipi-os-configurator-data-neuron)
+	# so unipiid's udev rule fires, detects the attached model, and stages the
+	# matching per-model udev rules for os-configurator.
+	echo "dtoverlay=unipi_id" >> ${DEPLOYDIR}/bootfiles/config.txt
+	# TEMPORARY DIAGNOSTIC ONLY Test device is a
+	# known S103. neuron-spi-new (generic, all-model) declares spi0 channel 1
+	# with compatible="unipispi" and no modbus-address/iogroup child, which
+	# unipi-kernel-modules' unipi_channel_init() silently ignores (no ttyNS).
+	# unipi_s103 fully re-declares that same spi0/channel-1 node with the
+	# modbus-address + iogroup(uart/gpio/aio) data the driver actually needs,
+	# so it replaces neuron-spi-new rather than adding to it - hence removed
+	# above. This hardcodes one specific model and is NOT the production fix
+	# (that needs per-unit model selection, not a build-time hardcode) - it's
+	# here only to empirically confirm the hypothesis on real hardware.
+	echo "dtoverlay=unipi_s103" >> ${DEPLOYDIR}/bootfiles/config.txt
 }
 
 # On Raspberry Pi 3 and Raspberry Pi Zero WiFi, serial ttyS0 console is only

--- a/layers/meta-balena-raspberrypi/recipes-extended/unipi-os-configurator-data-neuron/unipi-os-configurator-data-neuron_1.2.bb
+++ b/layers/meta-balena-raspberrypi/recipes-extended/unipi-os-configurator-data-neuron/unipi-os-configurator-data-neuron_1.2.bb
@@ -1,0 +1,65 @@
+SUMMARY = "UniPi OS Configurator data for Neuron/Axon boards - per-model device-tree overlays and staged udev rules"
+DESCRIPTION = "Provides the device-tree overlays and udev rules unipi-os-configurator activates at boot once it detects which specific Neuron model (L4xx/M3xx/S103/...) is attached, via its EEPROM-based hardware ID. Restores /dev/ttyNS* and other board-IO device nodes that the vendor's kernel-6.1+ rework (see unipi-kernel-modules) moved to this per-model mechanism, replacing the single generic overlay this device type used before."
+HOMEPAGE = "https://github.com/UniPiTechnology/os-configurator-data-neuron"
+LICENSE = "GPL-3.0-or-later"
+LIC_FILES_CHKSUM = "file://debian/copyright;md5=87e7938d0f6a1ed6761fd8a2abc0350c"
+
+SRC_URI = "git://github.com/UniPiTechnology/os-configurator-data-neuron.git;protocol=https;branch=master"
+
+# 1.2 - current tip as of writing.
+SRCREV = "23153abdade9f5defaca58a8b9e21d408468f840"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "dtc-native"
+RDEPENDS:${PN} += "unipi-os-configurator"
+
+COMPATIBLE_MACHINE = "(raspberrypi3-unipi-neuron|raspberrypi4-unipi-neuron)"
+
+inherit deploy
+
+do_compile() {
+    cd ${S}/overlays
+    for dts in *-overlay.dts; do
+        dtc -@ -O dtb -o "${dts%-overlay.dts}.dtbo" "${dts}"
+    done
+}
+
+do_install() {
+    install -d ${D}${datadir}/unipi-os-configurator/udev
+    install -m 0644 ${S}/udev/*.rules ${D}${datadir}/unipi-os-configurator/udev/
+
+    install -d ${D}${libdir}/unipi
+    install -m 0644 ${S}/unipi_values.py ${D}${libdir}/unipi/
+}
+
+FILES:${PN} += " \
+    ${datadir}/unipi-os-configurator/udev \
+    ${libdir}/unipi \
+"
+
+# What actually puts an overlay on the boot partition for this device's
+# balenaos-img fstype (meta-balena-raspberrypi/recipes-core/images/
+# balena-image.inc's overlay_dtbs_handler, a do_resin_boot_dirgen_and_deploy
+# prefunc):
+#   1. It reads DEPLOY_DIR_IMAGE/overlays.txt as the complete, authoritative
+#      list of overlay dtbo names (as "overlays/<name>.dtbo" entries) and
+#      REPLACES KERNEL_DEVICETREE with it - not a directory scan of any kind.
+#   2. overlays.txt itself is written by linux-raspberrypi's own do_overlays
+#      prefunc (recipes-kernel/linux/linux-raspberrypi_%.bbappend), which
+#      globs *-overlay.dts ONLY from the kernel recipe's own source tree and
+#      overwrites (not appends) the file - so anything from a different
+#      recipe has to be appended after that write, not before.
+#   3. make_dtb_boot_files() then expects each dtbo's SOURCE file sitting
+#      flat at DEPLOY_DIR_IMAGE/<name>.dtbo (matching where the kernel's own
+#      compiled overlays land) - not in any overlays/ or bootfiles/overlays/
+#      subdirectory (both tried and confirmed wrong before this).
+do_deploy() {
+    install -d ${DEPLOY_DIR_IMAGE}
+    install -m 0644 ${S}/overlays/*.dtbo ${DEPLOY_DIR_IMAGE}/
+    for f in ${S}/overlays/*.dtbo; do
+        echo -n " overlays/$(basename ${f})" >> ${DEPLOY_DIR_IMAGE}/overlays.txt
+    done
+}
+do_deploy[depends] += "virtual/kernel:do_deploy"
+addtask deploy after do_compile before do_build

--- a/layers/meta-balena-raspberrypi/recipes-extended/unipi-os-configurator/unipi-os-configurator_1.6.0.bb
+++ b/layers/meta-balena-raspberrypi/recipes-extended/unipi-os-configurator/unipi-os-configurator_1.6.0.bb
@@ -1,0 +1,80 @@
+SUMMARY = "UniPi OS Configurator - detects connected Neuron/Axon/Iris/Patron/G1 hardware and activates the matching device-tree overlay and udev rules"
+DESCRIPTION = "Package containing binary tools which detect connected UniPi HW and alter the behaviour of the OS: changing device tree overlays, setting udev rules, enabling/disabling daemons. Needs a product-specific unipi-os-configurator-data-<product> package for the actual per-model overlays/rules - see unipi-os-configurator-data-neuron."
+HOMEPAGE = "https://github.com/UniPiTechnology/os-configurator"
+LICENSE = "GPL-3.0-or-later"
+LIC_FILES_CHKSUM = "file://debian/copyright;md5=29243d19147dc9084f17c3e208fc70fb"
+
+SRC_URI = "git://github.com/UniPiTechnology/os-configurator.git;protocol=https;branch=main"
+
+# 1.6.0 - current tip as of writing.
+SRCREV = "6a7af1ff34cee12173ddabd0931621ac700b838a"
+
+S = "${WORKDIR}/git"
+
+# libcrypto (unipiid.c) and libi2c (unipiid.c EEPROM read)
+DEPENDS = "openssl i2c-tools"
+# python3 - os-configurator (the shell wrapper) execs os-configurator.py for
+# --update/--force; confirmed missing on real hardware ("python3: command not
+# found"), which silently breaks per-model udev rule activation. 
+RDEPENDS:${PN} += "bash python3"
+
+# The vendor Makefile's link lines don't reference $(LDFLAGS), so OE's
+# hardening/link flags never reach the linker (binaries come out missing
+# GNU_HASH etc). TARGET_CC_ARCH folds into $(CC) itself, so the Makefile
+# picks it up without needing to be patched. Same fix as unipi-tools.bb.
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+inherit systemd
+
+do_compile() {
+    oe_runmake -C ${S}/src
+}
+
+do_install() {
+    oe_runmake -C ${S}/src install DESTDIR=${D}
+
+    # files/* mirrors debian/install's "files/* -> /" - udev rules, run.d
+    # hook scripts, sysctl/default config, motd template. Deliberately
+    # excludes files/usr/share/keyrings: those are apt/dpkg repo signing
+    # keys for the vendor's own Debian-based image, meaningless (and
+    # potentially confusing) on an opkg-based balenaOS image.
+    cp -r ${S}/files/etc ${D}/
+    install -d ${D}${nonarch_base_libdir}
+    cp -r ${S}/files/usr/lib/udev ${D}${nonarch_base_libdir}/
+    install -d ${D}${libdir}/unipi ${D}${libdir}/unipi/run.d
+    install -m 0755 ${S}/files/usr/lib/unipi/run.d/*.sh ${D}${libdir}/unipi/run.d/
+    install -d ${D}${datadir}/unipi-os-configurator
+    cp -r ${S}/files/usr/share/unipi-os-configurator/motd ${D}${datadir}/unipi-os-configurator/
+
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 \
+        ${S}/debian/unipi-os-configurator.unipicheck.path \
+        ${S}/debian/unipi-os-configurator.unipicheck.service \
+        ${S}/debian/unipi-os-configurator.clear-bootcount.service \
+        ${S}/debian/unipi-os-configurator.unipi-motd.service \
+        ${D}${systemd_unitdir}/system/
+}
+
+FILES:${PN} += " \
+    ${nonarch_base_libdir}/udev \
+    ${libdir}/unipi \
+    ${datadir}/unipi-os-configurator \
+    ${sysconfdir}/default \
+    ${sysconfdir}/sysctl.d \
+    ${systemd_unitdir}/system/unipi-os-configurator.clear-bootcount.service \
+"
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = " \
+    unipi-os-configurator.unipicheck.path \
+    unipi-os-configurator.unipicheck.service \
+    unipi-os-configurator.unipi-motd.service \
+"
+# clear-bootcount.service is BindsTo=sys-devices-platform-bootcount.device
+# and its own [Install] wants that device, not a target - it activates
+# itself if/when that device appears, and never otherwise. Not included
+# in SYSTEMD_AUTO_ENABLE's unit list since there's nothing to "enable" it
+# against on this machine's known DT/kernel setup, but the unit file is
+# still installed (above) in case that assumption is wrong - flagged for
+# verification on real hardware via autokit rather than assumed either way.
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"

--- a/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_6.12.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/linux/linux-raspberrypi_6.12.bbappend
@@ -26,6 +26,14 @@ SRC_URI:append = " \
 
 SRC_URI:remove:raspberrypi = "file://0010-dts-overlays-Add-UniPi-overlays.patch"
 
+# NOTE: this 2021 patch's overlays (neuronee, neuron-spi-new)
+# are NOT superseded by unipi-os-configurator-data-neuron - rpi-config's
+# do_deploy:append:raspberrypi{3,4}-unipi-neuron already loads them via
+# dtoverlay= lines in config.txt and they provide the base SPI/hardware
+# wiring these boards need regardless of vendor kernel-module version. The
+# new os-configurator-data-neuron overlays are the vendor's ADDITIVE
+# per-model refinement on top of this, not a replacement - keep both.
+
 # The Pi3-64 and Pi4-64 are the only boards very low on rootfs space for now
 # so we add this as per https://github.com/balena-os/meta-balena/pull/2411
 BALENA_CONFIGS:append:raspberrypi4-64 = " optimize-size"

--- a/layers/meta-balena-raspberrypi/recipes-kernel/unipi-kernel-modules/unipi-kernel-modules.bb
+++ b/layers/meta-balena-raspberrypi/recipes-kernel/unipi-kernel-modules/unipi-kernel-modules.bb
@@ -8,8 +8,11 @@ SRC_URI = " \
 	git://github.com/UniPiTechnology/unipi-kernel-modules.git;protocol=https;nobranch=1 \
 "
 
-# Corresponds to 2.80.8
-SRCREV = "06ff9e5faa7a466e3feecbd6feefae5edb50f804"
+# Corresponds to 3.6 - the vendor's rework for kernel 6.1+ support (3.3:
+# "Remove support for Linux older than 6.1"). The previously-pinned 2.80.8
+# predates that rework and is why /dev/ttyNS* stopped appearing once this
+# device type's shared kernel moved to 6.12.61
+SRCREV = "3623cde6511758622eafe1b412fb69427e49004a"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Changelog-entry: Update unipi tooling to support kernel update


## Summary

`raspberrypi4-unipi-neuron` (and `raspberrypi3-unipi-neuron`) lost `/dev/ttyNS*` after this device type moved to kernel 6.12.61: the vendor reworked their kernel driver for 6.1+ support, moving from a driver that identified the attached board itself over SPI to one that requires the board's I/O layout to be declared explicitly in the device tree. This PR brings in the vendor's new driver and per-model device-tree data, and fixes several packaging/build-system issues along the way that were blocking it from actually reaching a running device.

## Changes

**Kernel driver** — `unipi-kernel-modules` bumped to the vendor's kernel-6.1+-compatible release.

**Base overlay retained** — the existing overlay patch (`neuronee`, `neuron-spi-new`, `unipiee`, etc.) stays in place for both UniPi machines; it provides base SPI/RTC wiring that's still required regardless of driver version.

**New recipe: `unipi-os-configurator-data-neuron`** — builds the vendor's ~21 per-model device-tree overlays and stages per-model udev rules. Its `do_deploy` installs the compiled overlays flat at `${DEPLOY_DIR_IMAGE}` and appends their names to the `overlays.txt` manifest, which is the only mechanism that actually gets an overlay onto this device's boot partition; it depends on the kernel recipe's own deploy step so its manifest entry isn't overwritten, and on `do_resin_boot_dirgen_and_deploy` so the boot partition is generated after the overlay content is in place.

**New recipe: `unipi-os-configurator` (built, not installed)** — packages the vendor's hardware-detection daemon, with a corrected `FILES` list, a link-flags fix so its binaries carry proper ELF hardening, and a `python3` runtime dependency it needs to actually run. It isn't installed on either machine: the shipped fix hardcodes the per-model overlay rather than relying on this daemon's runtime detection, so it isn't currently load-bearing, and `python3` alone is a meaningful chunk of an already-tight HUP size budget on this existing device type. It's kept as a working recipe for if/when per-unit dynamic model detection is built on top of the data package's staged udev rules.

**Machine config (`raspberrypi3/4-unipi-neuron.conf`)** — installs `unipi-kernel-modules`, `unipi-tools`, and `unipi-os-configurator-data-neuron`.

**Boot config (`rpi-config_git.bbappend`)** — adds `dtoverlay=unipi_id` on both machines to activate the EEPROM hardware-ID overlay. On `raspberrypi4-unipi-neuron`, replaces `dtoverlay=neuron-spi-new` with `dtoverlay=unipi_s103` — this is the overlay that actually creates `/dev/ttyNS0`, since it re-declares the same SPI node with the `modbus-address` and I/O-layout data the new driver requires. This hardcodes the specific model confirmed on the affected customer fleet; `HOST_CONFIG_dtoverlay` is the intended override path for any customer on a different physical Neuron model.

## Verified

Kernel builds clean; the per-model overlay reaches the boot partition and produces `/dev/ttyNS0` and the corresponding modbus character device on real hardware; `do_image_size_check` (the HUP compatibility check) passes on a production build. `IMAGE_ROOTFS_SIZE` was not changed for this existing, shipped device type.